### PR TITLE
added canonicalization details to provenance

### DIFF
--- a/fragmenter/tests/reference/butane.smi
+++ b/fragmenter/tests/reference/butane.smi
@@ -1,0 +1,1 @@
+CCCC butane

--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -6,7 +6,45 @@ Unit and regression test for the fragmenter package.
 import fragmenter
 import pytest
 import sys
+import unittest
+from fragmenter.tests.utils import get_fn, has_openeye
+
 
 def test_fragmenter_imported():
     """Sample test, will always pass so long as import statement worked"""
     assert "fragmenter" in sys.modules
+
+
+class TestFragment(unittest.TestCase):
+
+    @unittest.skipUnless(has_openeye, "Cannot test without openeye")
+    def test_generate_fragments(self):
+        """ generate fragments regression test"""
+        input_smi = get_fn('butane.smi')
+        fragments = fragmenter.generate_fragments(inputf=input_smi)
+
+        provenance = fragments['provenance']
+        canon_detail = provenance['canonicalization_details']
+        self.assertTrue(canon_detail['AtomMaps'])
+        self.assertTrue(canon_detail['AtomStereo'])
+        self.assertTrue(canon_detail['BondStereo'])
+        self.assertTrue(canon_detail['Canonical'])
+        self.assertTrue(canon_detail['Isotopes'])
+        self.assertTrue(canon_detail['RGroups'])
+        self.assertTrue(canon_detail['ISOMERIC'])
+        self.assertFalse(canon_detail['DEFAULT'])
+
+        with self.assertRaises(Warning):
+            fragmenter.generate_fragments(input_smi, OESMILESFlag='DEFAULT')
+
+        fragments = fragmenter.generate_fragments(input_smi, strict_stereo=False, OESMILESFlag='DEFAULT')
+        provenance = fragments['provenance']
+        canon_detail = provenance['canonicalization_details']
+        self.assertTrue(canon_detail['AtomMaps'])
+        self.assertFalse(canon_detail['AtomStereo'])
+        self.assertFalse(canon_detail['BondStereo'])
+        self.assertTrue(canon_detail['Canonical'])
+        self.assertFalse(canon_detail['Isotopes'])
+        self.assertTrue(canon_detail['RGroups'])
+        self.assertFalse(canon_detail['ISOMERIC'])
+        self.assertTrue(canon_detail['DEFAULT'])


### PR DESCRIPTION
## Description
Added canonicalization detail to provenance in JSON specs. Below is what the JSON structure looks like for butane:
```
{
    "CCCC": {
        "canonical_isomeric_SMILES": "CCCC",
        "crank_torsion_drives": {
            "crank_job_1": {
                "crank_specs": {
                    "model": {
                        "basis": "aug-cc-pVDZ",
                        "method": "B3LYP"
                    },
                    "options": {
                        "scf_type": "df"
                    }
                },
                "torsion_0": 30,
                "torsion_1": 30,
                "torsion_2": 30
            }
        },
        "molecule": {
            "geometry": [
                0.31914281845092773,
                -1.093637466430664,
                -1.5644147396087646,
                0.09283685684204102,
                -0.7512494325637817,
                -0.10052239894866943,
                -0.09279406070709229,
                0.7513599395751953,
                0.1004934310913086,
                -0.290915846824646,
                1.0967583656311035,
                1.5677818059921265,
                -0.5198796391487122,
                -0.7551677227020264,
                -2.180879592895508,
                1.2282583713531494,
                -0.6067847013473511,
                -1.931321620941162,
                0.43323153257369995,
                -2.1737723350524902,
                -1.7016046047210693,
                0.9486593008041382,
                -1.1027858257293701,
                0.48745453357696533,
                -0.7917245626449585,
                -1.287994146347046,
                0.26173627376556396,
                -0.960730254650116,
                1.099387764930725,
                -0.47136321663856506,
                0.7833671569824219,
                1.2891098260879517,
                -0.28042128682136536,
                -0.42176103591918945,
                2.176612377166748,
                1.6888495683670044,
                0.5750753879547119,
                0.7906937599182129,
                2.16329026222229,
                -1.1788761615753174,
                0.5997258424758911,
                1.971407413482666
            ],
            "molecular_charge": 0,
            "molecular_multiplicity": 1,
            "symbols": [
                "C",
                "C",
                "C",
                "C",
                "H",
                "H",
                "H",
                "H",
                "H",
                "H",
                "H",
                "H",
                "H",
                "H"
            ]
        },
        "needed_torsion_drives": {
            "torsion_0": [
                8,
                5,
                2,
                4
            ],
            "torsion_1": [
                2,
                5,
                8,
                11
            ],
            "torsion_2": [
                5,
                8,
                11,
                13
            ]
        },
        "provenance": {
            "canonicalization_details": {
                "AtomMaps": true,
                "AtomStereo": true,
                "BondStereo": true,
                "Canonical": true,
                "DEFAULT": false,
                "ISOMERIC": true,
                "Isotopes": true,
                "RGroups": true,
                "notes": "All other available OESMILESFlag are set to False",
                "oe_function": "openeye.oechem.OEMolToSmiles",
                "package": "openeye-v2017.Oct.1"
            },
            "job_id": "b56ab6cbcf09428297de9074d89b8838",
            "package": "fragmenter",
            "parent_molecule": "CCCC",
            "routine": "fragmenter.fragment.generate_fragments",
            "routine_options": {
                "MAX_ROTORS": 2,
                "OESMILESFlag": "ISOMERIC",
                "canonicalization": "openeye-v2017.Oct.1",
                "combinatorial": true,
                "generate_visualization": false,
                "inputf": "butane.smi",
                "json_filename": "fragments.json",
                "remove_map": false,
                "strict_stereo": true
            },
            "user": "chayastern",
            "version": "0.0.0+33.g5423652.dirty"
        },
        "tagged_SMARTS": "[H:5][C:1]([H:6])([H:7])[C:2]([H:8])([H:9])[C:3]([H:10])([H:11])[C:4]([H:12])([H:13])[H:14]"
    }
```
## Status
- [ ] Ready to go