### PR TITLE
Interfacing with crank

### DIFF
--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -66,6 +66,7 @@ def generate_fragments(inputf, generate_visualization=False, combinatorial=True,
     """
     options = copy.deepcopy(locals())
     fragments = dict()
+    #ToDo add both canonical isomeric and cononical SMILES to fragment provenance
     canonicalization_details = {'package': OPENEYE_VERSION, 'ISOMERIC': True,  'DEFAULT': False, 'Isotopes': True,
                                 'AtomStereo': True, 'BondStereo': True, 'Canonical': True, 'AtomMaps': True,
                                 'RGroups': True, 'oe_function': 'openeye.oechem.OEMolToSmiles', 'notes': 'All other available OESMILESFlag are set to False'}

--- a/fragmenter/tests/reference/butane_crankjob.json
+++ b/fragmenter/tests/reference/butane_crankjob.json
@@ -1,0 +1,138 @@
+{
+    "CCCC": {
+        "canonical_isomeric_SMILES": "CCCC",
+        "crank_torsion_drives": {
+            "crank_job_1": {
+                "crank_specs": {
+                    "model": {
+                        "basis": "aug-cc-pVDZ",
+                        "method": "B3LYP"
+                    },
+                    "options": {
+                        "scf_type": "df"
+                    }
+                },
+                "torsion_0": 30,
+                "torsion_1": 30,
+                "torsion_2": 30
+            }
+        },
+        "molecule": {
+            "geometry": [
+                0.31914281845092773,
+                -1.093637466430664,
+                -1.5644147396087646,
+                0.09283685684204102,
+                -0.7512494325637817,
+                -0.10052239894866943,
+                -0.09279406070709229,
+                0.7513599395751953,
+                0.1004934310913086,
+                -0.290915846824646,
+                1.0967583656311035,
+                1.5677818059921265,
+                -0.5198796391487122,
+                -0.7551677227020264,
+                -2.180879592895508,
+                1.2282583713531494,
+                -0.6067847013473511,
+                -1.931321620941162,
+                0.43323153257369995,
+                -2.1737723350524902,
+                -1.7016046047210693,
+                0.9486593008041382,
+                -1.1027858257293701,
+                0.48745453357696533,
+                -0.7917245626449585,
+                -1.287994146347046,
+                0.26173627376556396,
+                -0.960730254650116,
+                1.099387764930725,
+                -0.47136321663856506,
+                0.7833671569824219,
+                1.2891098260879517,
+                -0.28042128682136536,
+                -0.42176103591918945,
+                2.176612377166748,
+                1.6888495683670044,
+                0.5750753879547119,
+                0.7906937599182129,
+                2.16329026222229,
+                -1.1788761615753174,
+                0.5997258424758911,
+                1.971407413482666
+            ],
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+            "symbols": [
+                "C",
+                "C",
+                "C",
+                "C",
+                "H",
+                "H",
+                "H",
+                "H",
+                "H",
+                "H",
+                "H",
+                "H",
+                "H",
+                "H"
+            ]
+        },
+        "needed_torsion_drives": {
+            "torsion_0": [
+                3,
+                2,
+                1,
+                7
+            ],
+            "torsion_1": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "torsion_2": [
+                2,
+                3,
+                4,
+                13
+            ]
+        },
+        "provenance": {
+            "canonicalization_details": {
+                "AtomMaps": true,
+                "AtomStereo": true,
+                "BondStereo": true,
+                "Canonical": true,
+                "DEFAULT": false,
+                "ISOMERIC": true,
+                "Isotopes": true,
+                "RGroups": true,
+                "notes": "All other available OESMILESFlag are set to False",
+                "oe_function": "openeye.oechem.OEMolToSmiles",
+                "package": "openeye-v2017.Oct.1"
+            },
+            "job_id": "b6d0c461f9dd4ab59aa954415d5f432f",
+            "package": "fragmenter",
+            "parent_molecule": "CCCC",
+            "routine": "fragmenter.fragment.generate_fragments",
+            "routine_options": {
+                "MAX_ROTORS": 2,
+                "OESMILESFlag": "ISOMERIC",
+                "canonicalization": "openeye-v2017.Oct.1",
+                "combinatorial": true,
+                "generate_visualization": false,
+                "inputf": "../../../openforcefield/fragmenter/fragmenter/tests/reference/butane.smi",
+                "json_filename": null,
+                "remove_map": true,
+                "strict_stereo": true
+            },
+            "user": "chayastern",
+            "version": "0.0.0+37.gaa58fe7.dirty"
+        },
+        "tagged_SMARTS": "[H:5][C:1]([H:6])([H:7])[C:2]([H:8])([H:9])[C:3]([H:10])([H:11])[C:4]([H:12])([H:13])[H:14]"
+    }
+}

--- a/fragmenter/tests/test_torsions.py
+++ b/fragmenter/tests/test_torsions.py
@@ -1,6 +1,7 @@
 """ Tests generating files for qm torsion scan """
 
 import unittest
+import json
 from fragmenter.tests.utils import get_fn, has_openeye
 import fragmenter.torsions as torsions
 from fragmenter import utils
@@ -179,4 +180,14 @@ class TesTorsions(unittest.TestCase):
         with self.assertRaises(ValueError):
             torsions.define_crank_job(test_crank, [8, 25, 35])
 
+    def test_crank_initial_state(self):
+        """ Test generate crank initial state"""
+        jsonfile = open(get_fn('butane_crankjob.json'), 'r')
+        test_crank_job = json.load(jsonfile)
+        jsonfile.close()
+
+        crank_initial_state = torsions.get_initial_crank_state(test_crank_job['CCCC'])
+        self.assertEqual(crank_initial_state['crank_job_1']['dihedrals'], [[2, 1, 0, 6], [0, 1, 2, 3], [1, 2, 3, 12]])
+        self.assertEqual(crank_initial_state['crank_job_1']['grid_spacing'], [30, 30, 30])
+        self.assertFalse(crank_initial_state['crank_job_1']['grid_status'])
 

--- a/fragmenter/tests/test_torsions.py
+++ b/fragmenter/tests/test_torsions.py
@@ -187,7 +187,8 @@ class TesTorsions(unittest.TestCase):
         jsonfile.close()
 
         crank_initial_state = torsions.get_initial_crank_state(test_crank_job['CCCC'])
-        self.assertEqual(crank_initial_state['crank_job_1']['dihedrals'], [[2, 1, 0, 6], [0, 1, 2, 3], [1, 2, 3, 12]])
+        for dihedral in crank_initial_state['crank_job_1']['dihedrals']:
+            self.assertTrue(dihedral in [[2, 1, 0, 6], [0, 1, 2, 3], [1, 2, 3, 12]])
         self.assertEqual(crank_initial_state['crank_job_1']['grid_spacing'], [30, 30, 30])
         self.assertFalse(crank_initial_state['crank_job_1']['grid_status'])
 

--- a/fragmenter/tests/test_utils.py
+++ b/fragmenter/tests/test_utils.py
@@ -1,0 +1,25 @@
+"""Test util functions"""
+
+import unittest
+import json
+from fragmenter.tests.utils import get_fn, has_openeye
+from fragmenter import utils
+from openmoltools import openeye
+
+class TesTorsions(unittest.TestCase):
+
+    @unittest.skipUnless(has_openeye, 'Cannot test without openeye')
+    def test_is_mapped(self):
+        """Test checking if atom map exists"""
+        smiles = 'CCCC'
+        tagged_smiles = '[H:5][C:1]([H:6])([H:7])[C:2]([H:8])([H:9])[C:3]([H:10])([H:11])[C:4]([H:12])([H:13])[H:14]'
+        molecule = openeye.smiles_to_oemol(smiles)
+        tagged_molecule = openeye.smiles_to_oemol(tagged_smiles)
+
+        self.assertTrue(utils.is_mapped(tagged_molecule))
+        self.assertFalse(utils.is_mapped(molecule))
+
+        # Add tags
+        tagged_smiles = utils.create_mapped_smiles(molecule)
+        self.assertTrue(utils.is_mapped(molecule))
+

--- a/fragmenter/utils.py
+++ b/fragmenter/utils.py
@@ -241,6 +241,24 @@ def create_mapped_smiles(molecule):
     return oechem.OEMolToSmiles(molecule)
 
 
+def is_mapped(molecule):
+    """
+    Check if atoms are mapped. If any atom is missing a tag, this will return False
+    Parameters
+    ----------
+    molecule: OEMol
+
+    Returns
+    -------
+    Bool: True if mapped. False otherwise
+    """
+    IS_MAPPED = True
+    for atom in molecule.GetAtoms():
+        if atom.GetMapIdx() == 0:
+            IS_MAPPED = False
+    return IS_MAPPED
+
+
 def get_atom_map(tagged_smiles, molecule=None, is_mapped=False, StrictStereo=True):
     """
     Returns a dictionary that maps tag on SMILES to atom index in molecule.
@@ -280,6 +298,7 @@ def get_atom_map(tagged_smiles, molecule=None, is_mapped=False, StrictStereo=Tru
         if values.all():
             # Generate on Omega conformer
             molecule = openeye.generate_conformers(molecule, max_confs=1, strictStereo=StrictStereo)
+            # Omega can change the ordering so whatever map existed is not there anymore
 
     if is_mapped:
         atom_map = {}

--- a/fragmenter/utils.py
+++ b/fragmenter/utils.py
@@ -6,6 +6,8 @@ import json
 from uuid import UUID
 import numpy as np
 import itertools
+import re
+import codecs
 
 from openeye import oechem, oeiupac, oedepict
 from openmoltools import openeye
@@ -378,6 +380,115 @@ def to_mapped_xyz(molecule, atom_map, conformer=None, xyz_format=False, filename
     return xyz
 
 
+def to_psi4_input(fragment, molecule_name, memory='500 mb', command='gradient', symmetry='C1', crank_job='crank_job_1', filename=None):
+    """
+    Write out psi4 input for crank-launch input
+    Parameters
+    ----------
+    fragment: dict
+        JSON crank jobs for fragment
+    molecule_name: str
+        molecule name
+    memory: str
+        memory for psi4 job
+    command: str
+        gradient or optimize. Defualt is gradient. Must be gradient if using geomeTRIC for geometry optimization
+    symmetry: str
+        point group symmetry. Default is C1
+    crank_job: str
+        key for crank job in fragment dictionary. Default is crank_job_1
+    filename: str
+        Name for psi4 input file. Default is None. If None, function will return input string.
+
+    Returns
+    -------
+    psi4_input: str
+
+    """
+    job = fragment['crank_torsion_drives'][crank_job]
+    psi4_input = ""
+
+    if memory is not None:
+        psi4_input += "memory {}\n".format(memory)
+
+    psi4_input += "\nmolecule {}".format(molecule_name)
+    psi4_input += " {\n"
+    psi4_input += "symmetry {}\n".format(symmetry)
+    charge = fragment['molecule']['molecular_charge']
+    multiplicity = fragment['molecule']['molecular_multiplicity']
+    psi4_input += "{}  {} \n".format(charge, multiplicity)
+
+    # Convert 1-D Geom to 2-D geometry
+    n_atoms = len(fragment['molecule']['symbols'])
+    coords_3d = np.array(fragment['molecule']['geometry'], dtype=float).reshape(n_atoms, 3)
+
+    for element, coord in zip(fragment['molecule']['symbols'], coords_3d):
+        psi4_input += "%-7s %13.7f %13.7f %13.7f\n" % (element, coord[0], coord[1], coord[2])
+
+    psi4_input += "units Angstrom\n"
+    psi4_input += "}\n"
+
+    psi4_input += "\nset {\n"
+    psi4_input += " basis {}\n ".format(job['crank_specs']['model']['basis'])
+    try:
+        options = job['crank_specs']['options']
+        for option in options:
+            psi4_input += "{} {}\n".format(option, options[option])
+    except KeyError:
+        # No options were given
+        logger().info('no options found')
+        pass
+
+    psi4_input += "}\n"
+
+    psi4_input += "\n{}('{}')\n".format(command, job['crank_specs']['model']['method'])
+
+    if filename:
+        f = open(filename, 'w')
+        f.write(psi4_input)
+        f.close()
+    else:
+        return psi4_input
+
+
+def to_dihedraltxt(fragment, crank_job='crank_job_1', filename=None):
+    """
+    Generate dihedral txt file defining dihedrals that should be restraint in crank job
+
+    Parameters
+    ----------
+    fragment: dict
+        JSON crank jobs for fragment
+    crank_job: str
+        key for crank job to run
+    filename: str
+        filename of dihedral file. If None, returns input string.
+
+    Returns
+    -------
+    dih_input: str
+
+    """
+    needed_torsions = fragment['needed_torsion_drives']
+    crank_jobs = fragment['crank_torsion_drives'][crank_job]
+    dihedrals = []
+    for torsion in needed_torsions:
+        if torsion in crank_jobs:
+            dihedrals.append([i-1 for i in needed_torsions[torsion]])
+
+    dih_input = ""
+    dih_input += "# dihedral definition by atom indices starting from 0\n"
+    dih_input += "# i     j     k     l\n"
+    for dihedral in dihedrals:
+        dih_input += "  {}     {}     {}     {}\n".format(dihedral[0], dihedral[1], dihedral[2], dihedral[3])
+    if filename:
+        f = open(filename, 'w')
+        f.write(dih_input)
+        f.close()
+    else:
+        return dih_input
+
+
 def to_mapped_QC_JSON_geometry(molecule, atom_map, charge=0, multiplicity=1):
     """
     Generate xyz coordinates for molecule in the order given by the atom_map. atom_map is a dictionary that maps the
@@ -694,3 +805,128 @@ class UUIDEncoder(json.JSONEncoder):
             # if the obj is uuid, we simply return the value of uuid
             return obj.hex
         return json.JSONEncoder.default(self, obj)
+
+
+def make_python_identifier(string, namespace=None, reserved_words=None,
+                           convert='drop', handle='force'):
+    """
+    Taken from https://gist.github.com/JamesPHoughton
+    Takes an arbitrary string and creates a valid Python identifier.
+    If the python identifier created is already in the namespace,
+    or if the identifier is a reserved word in the reserved_words
+    list, or is a python default reserved word,
+    adds _1, or if _1 is in the namespace, _2, etc.
+    Parameters
+    ----------
+    string : <basestring>
+        The text to be converted into a valid python identifier
+    namespace : <dictionary>
+        Map of existing translations into python safe identifiers.
+        This is to ensure that two strings are not translated into
+        the same python identifier
+    reserved_words : <list of strings>
+        List of words that are reserved (because they have other meanings
+        in this particular program, such as also being the names of
+        libraries, etc.
+    convert : <string>
+        Tells the function what to do with characters that are not
+        valid in python identifiers
+        - 'hex' implies that they will be converted to their hexidecimal
+                representation. This is handy if you have variables that
+                have a lot of reserved characters
+        - 'drop' implies that they will just be dropped altogether
+    handle : <string>
+        Tells the function how to deal with namespace conflicts
+        - 'force' will create a representation which is not in conflict
+                  by appending _n to the resulting variable where n is
+                  the lowest number necessary to avoid a conflict
+        - 'throw' will raise an exception
+    Returns
+    -------
+    identifier : <string>
+        A vaild python identifier based on the input string
+    namespace : <dictionary>
+        An updated map of the translations of words to python identifiers,
+        including the passed in 'string'.
+    Examples
+    --------
+    >>> make_python_identifier('Capital')
+    ('capital', {'Capital': 'capital'})
+    >>> make_python_identifier('multiple words')
+    ('multiple_words', {'multiple words': 'multiple_words'})
+    >>> make_python_identifier('multiple     spaces')
+    ('multiple_spaces', {'multiple     spaces': 'multiple_spaces'})
+    When the name is a python keyword, add '_1' to differentiate it
+    >>> make_python_identifier('for')
+    ('for_1', {'for': 'for_1'})
+    Remove leading and trailing whitespace
+    >>> make_python_identifier('  whitespace  ')
+    ('whitespace', {'  whitespace  ': 'whitespace'})
+    Remove most special characters outright:
+    >>> make_python_identifier('H@t tr!ck')
+    ('ht_trck', {'H@t tr!ck': 'ht_trck'})
+    Replace special characters with their hex representations
+    >>> make_python_identifier('H@t tr!ck', convert='hex')
+    ('h40t_tr21ck', {'H@t tr!ck': 'h40t_tr21ck'})
+    remove leading digits
+    >>> make_python_identifier('123abc')
+    ('abc', {'123abc': 'abc'})
+    namespace conflicts
+    >>> make_python_identifier('Variable$', namespace={'Variable@':'variable'})
+    ('variable_1', {'Variable@': 'variable', 'Variable$': 'variable_1'})
+    >>> make_python_identifier('Variable$', namespace={'Variable@':'variable', 'Variable%':'variable_1'})
+    ('variable_2', {'Variable@': 'variable', 'Variable%': 'variable_1', 'Variable$': 'variable_2'})
+    throw exception instead
+    >>> make_python_identifier('Variable$', namespace={'Variable@':'variable'}, handle='throw')
+    Traceback (most recent call last):
+     ...
+    NameError: variable already exists in namespace or is a reserved word
+    References
+    ----------
+    Identifiers must follow the convention outlined here:
+        https://docs.python.org/2/reference/lexical_analysis.html#identifiers
+    """
+    if namespace is None:
+        namespace = {}
+
+    if reserved_words is None:
+        reserved_words = []
+
+    # create a working copy (and make it lowercase, while we're at it)
+    s = string.lower()
+
+    # remove leading and trailing whitespace
+    s = s.strip()
+
+    # Make spaces into underscores
+    s = re.sub('[\\s\\t\\n]+', '_', s)
+
+    if convert == 'hex':
+        # Convert invalid characters to hex
+        hexlify = codecs.getencoder('hex')
+        s = ''.join(['_' + (hexlify(c.encode('utf-8'))[0]).decode('utf-8') + '_'
+                     if re.findall('[^0-9a-zA-Z_]', c) else c for c in s])
+
+    elif convert == 'drop':
+        # Remove invalid characters
+        s = re.sub('[^0-9a-zA-Z_]', '', s)
+
+    # Remove leading characters until we find a letter or underscore
+    s = re.sub('^[^a-zA-Z_]+', '', s)
+
+    # Check that the string is not a python identifier
+    while (#s in keyword.kwlist or
+           s in namespace.values() or
+           s in reserved_words):
+        if handle == 'throw':
+            raise NameError(s + ' already exists in namespace or is a reserved word')
+        if handle == 'force':
+            if re.match(".*?_\d+$", s):
+                i = re.match(".*?_(\d+)$", s).groups()[0]
+                s = s.strip('_'+i) + '_'+str(int(i)+1)
+            else:
+                s += '_1'
+
+    namespace[string] = s
+
+    return s, namespace


### PR DESCRIPTION
## Description
This PR adds the ability to:
1) Generate input files for `crank-launch` and launch crank
2) Generate initial crank state 

This PR also fixes a bug. When a new conformer is generated the atom map remain but the molecule data is removed. The check in `find_torsions` didn't detect the mapping and generated a new tagged SMARTS which had a different ordering and the torsion indices didn't correspond to the atom maps. The function `is_mapped` now checks if the atoms have maps. 

## Status
- [ ] Ready to go