### PR TITLE
Isomeric canonical and non-isomeric canonical SMILES

### DIFF
--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -31,7 +31,7 @@ def fragment_to_torsion_scan(fragments, json_filename=None):
     Returns
     -------
     molecules: dict
-        dictionary that maps fragment SMILES to crank job specs (includes torsions to drive, carnk specs and provenance)
+        dictionary that maps fragment SMILES to crank job specs (includes torsions to drive, crank specs and provenance)
     """
     provenance = fragments['provenance']
     molecules = {}
@@ -42,15 +42,10 @@ def fragment_to_torsion_scan(fragments, json_filename=None):
             json_specs['provenance']['parent_molecule'] = parent
             json_specs['canonical_isomeric_SMILES'] = frag
             molecule = openeye.smiles_to_oemol(frag)
+            json_specs['canonical_SMILES'] = oechem.OECreateCanSmiString(molecule)
             tagged_SMARTS = utils.create_mapped_smiles(molecule)
             json_specs['tagged_SMARTS'] = tagged_SMARTS
-
-            # Check if SMILES have stereochemistry
-            if provenance['canonicalization_details']['DEFAULT']:
-                StrictStereo = False
-            else:
-                StrictStereo = True
-            molecule, atom_map = utils.get_atom_map(tagged_SMARTS, is_mapped=True, StrictStereo=StrictStereo)
+            molecule, atom_map = utils.get_atom_map(tagged_SMARTS, is_mapped=True)
             QC_JSON_molecule = utils.to_mapped_QC_JSON_geometry(molecule, atom_map)
             json_specs['molecule'] = QC_JSON_molecule
             needed_torsion_drives = find_torsions(molecule)


### PR DESCRIPTION
## Description
This PR addresses https://github.com/openforcefield/fragmenter/issues/5
This PR adds an isomeric and non-isomeric canonical SMILES to the fragment JSON specs. It also removes the option to only generate non-isomeric canonical SMILES.  

## Questions
- [ ] Should we store the part of the code that generates these SMILES in a separate repo with a pinned OpenEye version to ensure that we always generate SMILES with the same canonicalization algorithm?  
- [ ] Should we allow different cheminformatic packages? OpenEye needs license. 

## Status
- [ ] Ready to go