### PR TITLE
Expand states

### DIFF
--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -70,7 +70,7 @@ def expand_states(molecule, protonation=True, tautomers=False, stereoisomers=Tru
         molecules.extend(_expand_states(molecules, enumerate='stereoisomers', maxstates=maxstates, verbose=verbose))
 
     for molecule in molecules:
-        states.add(fragmenter.utils.create_mapped_smiles(molecule, tagged=False, explicit_h=False))
+        states.add(fragmenter.utils.create_mapped_smiles(molecule, tagged=False, explicit_hydrogen=False))
 
     if filename:
         count = 0
@@ -151,7 +151,7 @@ def generate_fragments(inputf, generate_visualization=False, strict_stereo=True,
     This function generates fragments from molecules. The output is a dictionary that maps SMILES of molecules to SMILES
      for fragments. The default SMILES are generated with openeye.oechem.OEMolToSmiles. These SMILES strings are canonical
      isomeric SMILES.
-     The dictionary also includes a providence field which defines how the fragments were generated.
+     The dictionary also includes a provenance field which defines how the fragments were generated.
 
     Parameters
     ----------

--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -20,7 +20,7 @@ OPENEYE_VERSION = oe.__name__ + '-v' + oe.__version__
 
 
 def expand_states(molecule, protonation=True, tautomers=False, stereoisomers=True, consider_aromaticity=True, maxstates=200,
-                  verbose=True, filename=None):
+                  verbose=True, filename=None, return_smiles_list=False):
     """
     Expand molecule states (choice of protonation, tautomers and/or stereoisomers).
     Protonation states expands molecules to protonation of protonation sites (Some states might only be reasonable in
@@ -34,19 +34,21 @@ def expand_states(molecule, protonation=True, tautomers=False, stereoisomers=Tru
     ----------
     molecule: OEMol
         Molecule to expand
-    protonation: Bool
-        If True will enumerate protonation states. Default True
-    tautomers: Bool
-        If True, will enumerate tautomers. Default False (Note: This is False because results usually give resonance structures
+    protonation: Bool, optional, default=True
+        If True will enumerate protonation states.
+    tautomers: Bool, optional, default=False
+        If True, will enumerate tautomers.  (Note: Default is False because results usually give resonance structures
         which ins't needed for torsion scans
-    stereoisomers: Bool
-        If True will enumerate stereoisomers (cis/trans and R/S). Default is True
-    consider_atomaticity: Bool
-    maxstates: int
-        Defulat 200
-    verbose: Bool
-    filename: str
-        Filename to save SMILES to. If None, SMILES will not be saved to file. Defualt None.
+    stereoisomers: Bool, optional, default=True
+        If True will enumerate stereoisomers (cis/trans and R/S).
+    consider_atomaticity: Bool, optional, default=True
+    maxstates: int, optional, default=True
+    verbose: Bool, optiona, default=True
+    filename: str, optional, default=None
+        Filename to save SMILES to. If None, SMILES will not be saved to file.
+    return_smiles_list: bool, optional, default=False
+        If True, will return a list of SMILES with numbered name of molecule. Use this if you want ot write out an
+        smi file of all molecules processed with a unique numbered name for each state.
 
     Returns
     -------
@@ -67,14 +69,9 @@ def expand_states(molecule, protonation=True, tautomers=False, stereoisomers=Tru
     if stereoisomers:
         molecules.extend(_expand_states(molecules, enumerate='stereoisomers', maxstates=maxstates, verbose=verbose))
 
-    if filename:
-        oname = filename
-        ofs = oechem.oemolostream()
-        if not ofs.open(oname):
-            oechem.OEThrow.Fatal('Unable to open {} for writing molecules.'.format(oname))
-
     for molecule in molecules:
         states.add(fragmenter.utils.create_mapped_smiles(molecule, tagged=False, explicit_h=False))
+
     if filename:
         count = 0
         smiles_list = []
@@ -84,10 +81,32 @@ def expand_states(molecule, protonation=True, tautomers=False, stereoisomers=Tru
             smiles_list.append(molecule)
         fragmenter.utils.to_smi(smiles_list, filename)
 
+    if return_smiles_list:
+        return smiles_list
+
     return states
 
 
 def _expand_states(molecules, enumerate='protonation', consider_aromaticity=True, maxstates=200, verbose=True):
+    """
+    Expand the state specified by enumerate variable
+
+    Parameters
+    ----------
+    molecules: OEMol or list of OEMol
+        molecule to expand states
+    enumerate: str, optional, default='protonation'
+        Kind of state to enumerate. Choice of protonation, tautomers, stereoiserms
+    consider_aromaticity: Bool, optiona, default True
+    maxstates: int, optional, default=200
+    verbose: Bool, optional, deault=TRue
+
+    Returns
+    -------
+    states: list of OEMol
+        enumerated states
+
+    """
     if type(molecules) != type(list()):
         molecules = [molecules]
 

--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -185,11 +185,16 @@ def generate_fragments(inputf, generate_visualization=False, strict_stereo=True,
     options = copy.deepcopy(locals())
     fragments = dict()
     canonicalization_details = {'package': OPENEYE_VERSION,
-                                'canonical_isomeric_SMILES': {'Flags_set_to_True': ['ISOMERIC', 'Isotopes', 'AtomStereo',
-                                                                                     'BondStereo', 'Canonical', 'AtomMaps', 'RGroups'],
+                                'canonical_isomeric_SMILES': {'Flags': ['ISOMERIC', 'Isotopes', 'AtomStereo',
+                                                                        'BondStereo', 'Canonical', 'AtomMaps', 'RGroups'],
                                                                'oe_function': 'openeye.oechem.OEMolToSmiles(molecule)'},
-                                'canonical_SMILES': {'Flags_set_to_True': ['DEFAULT', 'Canonical', 'AtomMaps', 'RGroups'],
+                                'canonical_SMILES': {'Flags': ['DEFAULT', 'Canonical', 'AtomMaps', 'RGroups'],
                                                       'oe_function': 'openeye.oechem.OECreateCanSmiString(molecule)'},
+                                'canonical_isomeric_explicit_hydrogen_SMILES': {'Flags': ['Hydrogens', 'Isotopes', 'AtomStereo',
+                                                                                          'BondStereo', 'Canonical', 'RGroups'],
+                                                                                'oe_function': 'openeye.oechem.OECreateSmiString()'},
+                                'canonical_explicit_hydrogen_SMILES': {'Flags': ['Hydrogens', 'Canonical', 'RGroups'],
+                                                                       'oe_function': 'openeye.oechem.OECreateSmiString()'},
                                 'notes': 'All other available OESMIELSFlag are set to False'}
 
 

--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -71,7 +71,7 @@ class TestFragment(unittest.TestCase):
                          'Cc1ccc(cc1[N-]c2nccc(n2)c3cccnc3)NC(=O)c4ccc(cc4)C[NH+]5CC[NH+](CC5)C'}
         protonation_2 = set()
         for mol in protonation:
-            protonation_2.add(fragmenter.utils.create_mapped_smiles(mol, tagged=False, explicit_h=False))
+            protonation_2.add(fragmenter.utils.create_mapped_smiles(mol, tagged=False, explicit_hydrogen=False))
 
         intersection = protonation_1.intersection(protonation_2)
         self.assertEqual(len(intersection), len(protonation_1))
@@ -87,7 +87,7 @@ class TestFragment(unittest.TestCase):
                         'Cc1cccc(c1[NH+]=C(c2cnc(s2)Nc3cc(nc(n3)C)N4CCN(CC4)CCO)[O-])Cl'}
         tautomers_2 = set()
         for mol in tautomers:
-            tautomers_2.add(fragmenter.utils.create_mapped_smiles(mol, tagged=False, explicit_h=False))
+            tautomers_2.add(fragmenter.utils.create_mapped_smiles(mol, tagged=False, explicit_hydrogen=False))
 
         intersection = tautomers_1.intersection(tautomers_2)
         self.assertEqual(len(tautomers_1), len(intersection))
@@ -106,7 +106,7 @@ class TestFragment(unittest.TestCase):
 
         stereoisomers_2 = set()
         for mol in stereoisomers:
-            stereoisomers_2.add(fragmenter.utils.create_mapped_smiles(mol, tagged=False, explicit_h=False))
+            stereoisomers_2.add(fragmenter.utils.create_mapped_smiles(mol, tagged=False, explicit_hydrogen=False))
         intersection = stereoisomers_1.intersection(stereoisomers_2)
         self.assertEqual(len(intersection), len(stereoisomers_1))
         self.assertEqual(len(intersection), len(stereoisomers_2))

--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -26,10 +26,10 @@ class TestFragment(unittest.TestCase):
         provenance = fragments['provenance']
         canon_detail = provenance['canonicalization_details']
         isomeric_smiles = canon_detail['canonical_isomeric_SMILES']
-        for flag in isomeric_smiles['Flags_set_to_True']:
+        for flag in isomeric_smiles['Flags']:
             self.assertTrue(flag in ['ISOMERIC', 'Isotopes', 'AtomStereo', 'BondStereo', 'Canonical', 'AtomMaps', 'RGroups'])
         canonical_smiles = canon_detail['canonical_SMILES']
-        for flag in canonical_smiles['Flags_set_to_True']:
+        for flag in canonical_smiles['Flags']:
             print(flag)
             self.assertTrue(flag in ['DEFAULT', 'AtomMaps', 'Canonical', 'RGroups'])
 

--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -48,5 +48,69 @@ class TestFragment(unittest.TestCase):
         fragmenter.fragment._generate_fragments(mol_2)
         fragmenter.fragment._generate_fragments(mol_3)
 
+    def test_expand_protonation_states(self):
+        """Test expand protonation states"""
+        smiles = 'C5=C(C1=CN=CC=C1)N=C(NC2=C(C=CC(=C2)NC(C3=CC=C(C=C3)CN4CCN(CC4)C)=O)C)N=C5'
+        molecule = openeye.smiles_to_oemol(smiles)
+        protonation = fragmenter.fragment._expand_states(molecule)
+        protonation_1 = {'Cc1ccc(cc1Nc2nccc(n2)c3ccc[nH+]c3)NC(=O)c4ccc(cc4)CN5CCN(CC5)C',
+                         'Cc1ccc(cc1Nc2nccc(n2)c3ccc[nH+]c3)NC(=O)c4ccc(cc4)CN5CC[NH+](CC5)C',
+                         'Cc1ccc(cc1Nc2nccc(n2)c3ccc[nH+]c3)NC(=O)c4ccc(cc4)C[NH+]5CCN(CC5)C',
+                         'Cc1ccc(cc1Nc2nccc(n2)c3ccc[nH+]c3)NC(=O)c4ccc(cc4)C[NH+]5CC[NH+](CC5)C',
+                         'Cc1ccc(cc1Nc2nccc(n2)c3cccnc3)NC(=O)c4ccc(cc4)CN5CCN(CC5)C',
+                         'Cc1ccc(cc1Nc2nccc(n2)c3cccnc3)NC(=O)c4ccc(cc4)CN5CC[NH+](CC5)C',
+                         'Cc1ccc(cc1Nc2nccc(n2)c3cccnc3)NC(=O)c4ccc(cc4)C[NH+]5CCN(CC5)C',
+                         'Cc1ccc(cc1Nc2nccc(n2)c3cccnc3)NC(=O)c4ccc(cc4)C[NH+]5CC[NH+](CC5)C',
+                         'Cc1ccc(cc1[N-]c2nccc(n2)c3ccc[nH+]c3)NC(=O)c4ccc(cc4)CN5CCN(CC5)C',
+                         'Cc1ccc(cc1[N-]c2nccc(n2)c3ccc[nH+]c3)NC(=O)c4ccc(cc4)CN5CC[NH+](CC5)C',
+                         'Cc1ccc(cc1[N-]c2nccc(n2)c3ccc[nH+]c3)NC(=O)c4ccc(cc4)C[NH+]5CCN(CC5)C',
+                         'Cc1ccc(cc1[N-]c2nccc(n2)c3ccc[nH+]c3)NC(=O)c4ccc(cc4)C[NH+]5CC[NH+](CC5)C',
+                         'Cc1ccc(cc1[N-]c2nccc(n2)c3cccnc3)NC(=O)c4ccc(cc4)CN5CCN(CC5)C',
+                         'Cc1ccc(cc1[N-]c2nccc(n2)c3cccnc3)NC(=O)c4ccc(cc4)CN5CC[NH+](CC5)C',
+                         'Cc1ccc(cc1[N-]c2nccc(n2)c3cccnc3)NC(=O)c4ccc(cc4)C[NH+]5CCN(CC5)C',
+                         'Cc1ccc(cc1[N-]c2nccc(n2)c3cccnc3)NC(=O)c4ccc(cc4)C[NH+]5CC[NH+](CC5)C'}
+        protonation_2 = set()
+        for mol in protonation:
+            protonation_2.add(fragmenter.utils.create_mapped_smiles(mol, tagged=False, explicit_h=False))
+
+        intersection = protonation_1.intersection(protonation_2)
+        self.assertEqual(len(intersection), len(protonation_1))
+        self.assertEqual(len(intersection), len(protonation_2))
+
+    def test_expand_tautomers(self):
+        """Test expand tautomer"""
+        smiles ='C1=C(SC(=N1)NC2=CC(=NC(=N2)C)N3CCN(CC3)CCO)C(=O)NC4=C(C=CC=C4Cl)C'
+        molecule = openeye.smiles_to_oemol(smiles)
+        tautomers = fragmenter.fragment._expand_states(molecule, enumerate='tautomers')
+        tautomers_1 = {'Cc1cccc(c1NC(=C2C=NC(=[NH+]c3cc(nc(n3)C)N4CCN(CC4)CCO)S2)[O-])Cl',
+                        'Cc1cccc(c1NC(=O)c2cnc(s2)Nc3cc(nc(n3)C)N4CCN(CC4)CCO)Cl',
+                        'Cc1cccc(c1[NH+]=C(c2cnc(s2)Nc3cc(nc(n3)C)N4CCN(CC4)CCO)[O-])Cl'}
+        tautomers_2 = set()
+        for mol in tautomers:
+            tautomers_2.add(fragmenter.utils.create_mapped_smiles(mol, tagged=False, explicit_h=False))
+
+        intersection = tautomers_1.intersection(tautomers_2)
+        self.assertEqual(len(tautomers_1), len(intersection))
+        self.assertEqual(len(tautomers_2), len(intersection))
+        self.assertEqual(len(tautomers_1), len(tautomers_2))
+
+    def test_expand_enantiomers(self):
+        smiles = 'CN(C)C/C=C/C(=O)NC1=C(C=C2C(=C1)C(=NC=N2)NC3=CC(=C(C=C3)F)Cl)O[C@H]4CCOC4'
+        molecule = openeye.smiles_to_oemol(smiles)
+        stereoisomers = fragmenter.fragment._expand_states(molecule, enumerate='stereoisomers')
+
+        stereoisomers_1 = {'CN(C)C/C=C/C(=O)Nc1cc2c(cc1O[C@@H]3CCOC3)ncnc2Nc4ccc(c(c4)Cl)F',
+                        'CN(C)C/C=C/C(=O)Nc1cc2c(cc1O[C@H]3CCOC3)ncnc2Nc4ccc(c(c4)Cl)F',
+                        'CN(C)C/C=C\\C(=O)Nc1cc2c(cc1O[C@@H]3CCOC3)ncnc2Nc4ccc(c(c4)Cl)F',
+                        'CN(C)C/C=C\\C(=O)Nc1cc2c(cc1O[C@H]3CCOC3)ncnc2Nc4ccc(c(c4)Cl)F'}
+
+        stereoisomers_2 = set()
+        for mol in stereoisomers:
+            stereoisomers_2.add(fragmenter.utils.create_mapped_smiles(mol, tagged=False, explicit_h=False))
+        intersection = stereoisomers_1.intersection(stereoisomers_2)
+        self.assertEqual(len(intersection), len(stereoisomers_1))
+        self.assertEqual(len(intersection), len(stereoisomers_2))
+        self.assertEqual(len(stereoisomers_1), len(stereoisomers_2))
+
 
 

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -44,9 +44,9 @@ def fragment_to_torsion_scan(fragments, json_filename=None):
             molecule = openeye.smiles_to_oemol(frag)
             json_specs['canonical_SMILES'] = oechem.OECreateCanSmiString(molecule)
             explicit_h_isomeric = utils.create_mapped_smiles(molecule, tagged=False)
-            json_specs['explicit_H_canonical_isomeric_SMILES'] = explicit_h_isomeric
+            json_specs['explicit_hydrogen_canonical_isomeric_SMILES'] = explicit_h_isomeric
             explicit_h = utils.create_mapped_smiles(molecule, tagged=False, isomeric=False)
-            json_specs['explicit_H_canonical_SMILES'] = explicit_h
+            json_specs['explicit_hydrogen_canonical_SMILES'] = explicit_h
             tagged_SMARTS = utils.create_mapped_smiles(molecule)
             json_specs['tagged_SMARTS'] = tagged_SMARTS
             molecule, atom_map = utils.get_atom_map(tagged_SMARTS, is_mapped=True)

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -43,8 +43,10 @@ def fragment_to_torsion_scan(fragments, json_filename=None):
             json_specs['canonical_isomeric_SMILES'] = frag
             molecule = openeye.smiles_to_oemol(frag)
             json_specs['canonical_SMILES'] = oechem.OECreateCanSmiString(molecule)
-            explicit_h = utils.create_mapped_smiles(molecule, tagged=False)
-            json_specs['explicit_H_canonical_isomeric_SMILES'] = explicit_h
+            explicit_h_isomeric = utils.create_mapped_smiles(molecule, tagged=False)
+            json_specs['explicit_H_canonical_isomeric_SMILES'] = explicit_h_isomeric
+            explicit_h = utils.create_mapped_smiles(molecule, tagged=False, isomeric=False)
+            json_specs['explicit_H_canonical_SMILES'] = explicit_h
             tagged_SMARTS = utils.create_mapped_smiles(molecule)
             json_specs['tagged_SMARTS'] = tagged_SMARTS
             molecule, atom_map = utils.get_atom_map(tagged_SMARTS, is_mapped=True)

--- a/fragmenter/utils.py
+++ b/fragmenter/utils.py
@@ -29,7 +29,7 @@ def write_oedatabase(moldb, ofs, mlist, size):
         moldb.WriteMolecule(ofs, molidx)
 
 
-def to_smi(smiles, path, base, return_fname=False):
+def to_smi(smiles, filename, return_fname=False):
     """
     This function writes out an .smi file for a list of SMILES
     Parameters
@@ -42,13 +42,13 @@ def to_smi(smiles, path, base, return_fname=False):
         base name for output file
 
     """
-    fname = os.path.join(path, base + '.smi')
-    outf = open(fname, 'w')
+
+    outf = open(filename, 'w')
     smiles_list = map(lambda x: x+"\n", list(smiles))
     outf.writelines(smiles_list)
     outf.close()
     if return_fname:
-        return fname
+        return filename
 
 
 def create_oedatabase_idxfile(ifname):
@@ -213,7 +213,7 @@ def mol_to_tagged_smiles(infile, outfile):
         oechem.OEWriteMolecule(ofs, mol)
 
 
-def create_mapped_smiles(molecule, tagged=True):
+def create_mapped_smiles(molecule, tagged=True, explicit_h=True, isomeric=True):
     """
     Generate an index-tagged explicit hydrogen SMILES.
     Exmaple:
@@ -231,10 +231,15 @@ def create_mapped_smiles(molecule, tagged=True):
 
     """
     #ToDo check if tags already exist raise warning about overwritting existing tags. Maybe also add an option to override existing tags
+    if not explicit_h and not tagged:
+        return oechem.OEMolToSmiles(molecule)
     oechem.OEAddExplicitHydrogens(molecule)
-    if not tagged:
+    if not tagged and explicit_h and isomeric:
         return oechem.OECreateSmiString(molecule, oechem.OESMILESFlag_Hydrogens | oechem.OESMILESFlag_Isotopes | oechem.OESMILESFlag_AtomStereo
                                         | oechem.OESMILESFlag_BondStereo | oechem.OESMILESFlag_Canonical | oechem.OESMILESFlag_RGroups)
+    if not tagged and explicit_h and not isomeric:
+        return oechem.OECreateSmiString(molecule, oechem.OESMILESFlag_Hydrogens | oechem.OESMILESFlag_Canonical |
+                                        oechem.OESMILESFlag_RGroups)
 
     for atom in molecule.GetAtoms():
         atom.SetMapIdx(atom.GetIdx() + 1)


### PR DESCRIPTION
## Description
This PR expands an incoming molecule to its protonation states, tautomers and stereoisomers. It addressed issues https://github.com/openforcefield/fragmenter/issues/6 and https://github.com/openforcefield/fragmenter/issues/5

The default settings enumerate protonation states and stereoisomers. The results for kinase inhibitors are here:
https://github.com/choderalab/fragmenter_examples/blob/tautomers/tautomer_enumeration/states.xlsx

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Enumerate protonation states
  - [ ] Enumerate tautomers 
  - [x] Enumerate stereoisomers 

## Questions
- [ ] Currently enumerating tautomers is set to False by default. That's because most tuatomers are just different resonance structures which is not something we need. 

## Status
- [ ] Ready to go