### PR TITLE
Allow more complex scan grids

### DIFF
--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -13,7 +13,7 @@ import itertools
 import uuid
 import json
 
-from .utils import logger, normalize_molecule, new_output_stream, write_oedatabase, UUIDEncoder
+from .utils import logger, normalize_molecule, new_output_stream, write_oedatabase
 import fragmenter
 
 OPENEYE_VERSION = oe.__name__ + '-v' + oe.__version__
@@ -230,7 +230,7 @@ def generate_fragments(inputf, generate_visualization=False, strict_stereo=True,
 
 
     fragments['fragments'] = {}
-    fragments['provenance'] = {'job_id': uuid.uuid4(), 'package': fragmenter.__package__, 'version': fragmenter.__version__,
+    fragments['provenance'] = {'job_id': uuid.uuid4().hex, 'package': fragmenter.__package__, 'version': fragmenter.__version__,
                                'routine': generate_fragments.__module__ + '.' + generate_fragments.__name__,
                                'canonicalization_details': canonicalization_details,
                                'user': pwd.getpwuid(os.getuid()).pw_name, 'routine_options': options}
@@ -266,7 +266,7 @@ def generate_fragments(inputf, generate_visualization=False, strict_stereo=True,
             del charged, frags
     if json_filename:
         f = open(json_filename, 'w')
-        j = json.dump(fragments, f, indent=4, sort_keys=True, cls=UUIDEncoder)
+        j = json.dump(fragments, f, indent=4, sort_keys=True)
         f.close()
 
     return fragments

--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -230,7 +230,7 @@ def generate_fragments(inputf, generate_visualization=False, strict_stereo=True,
 
 
     fragments['fragments'] = {}
-    fragments['provenance'] = {'job_id': uuid.uuid4().hex, 'package': fragmenter.__package__, 'version': fragmenter.__version__,
+    fragments['provenance'] = {'job_id': str(uuid.uuid4()), 'package': fragmenter.__package__, 'version': fragmenter.__version__,
                                'routine': generate_fragments.__module__ + '.' + generate_fragments.__name__,
                                'canonicalization_details': canonicalization_details,
                                'user': pwd.getpwuid(os.getuid()).pw_name, 'routine_options': options}

--- a/fragmenter/tests/reference/butane_crankjob.json
+++ b/fragmenter/tests/reference/butane_crankjob.json
@@ -1,8 +1,9 @@
 {
     "CCCC": {
+        "canonical_SMILES": "CCCC",
         "canonical_isomeric_SMILES": "CCCC",
         "crank_torsion_drives": {
-            "crank_job_1": {
+            "crank_job_0": {
                 "crank_specs": {
                     "model": {
                         "basis": "aug-cc-pVDZ",
@@ -12,11 +13,17 @@
                         "scf_type": "df"
                     }
                 },
-                "torsion_0": 30,
-                "torsion_1": 30,
-                "torsion_2": 30
+                "mid_torsions": {
+                    "torsion_0": 30
+                },
+                "terminal_torsions": {
+                    "torsion_0": 30,
+                    "torsion_1": 30
+                }
             }
         },
+        "explicit_hydrogen_canonical_SMILES": "[H]C([H])([H])C([H])([H])C([H])([H])C([H])([H])[H]",
+        "explicit_hydrogen_canonical_isomeric_SMILES": "[H]C([H])([H])C([H])([H])C([H])([H])C([H])([H])[H]",
         "molecule": {
             "geometry": [
                 0.31914281845092773,
@@ -82,56 +89,92 @@
             ]
         },
         "needed_torsion_drives": {
-            "torsion_0": [
-                3,
-                2,
-                1,
-                7
-            ],
-            "torsion_1": [
-                1,
-                2,
-                3,
-                4
-            ],
-            "torsion_2": [
-                2,
-                3,
-                4,
-                13
-            ]
+            "mid": {
+                "grid_spacing": 30,
+                "torsion_0": [
+                    1,
+                    2,
+                    3,
+                    4
+                ]
+            },
+            "terminal": {
+                "grid_spacing": 30,
+                "torsion_0": [
+                    3,
+                    2,
+                    1,
+                    5
+                ],
+                "torsion_1": [
+                    2,
+                    3,
+                    4,
+                    12
+                ]
+            }
         },
         "provenance": {
             "canonicalization_details": {
-                "AtomMaps": true,
-                "AtomStereo": true,
-                "BondStereo": true,
-                "Canonical": true,
-                "DEFAULT": false,
-                "ISOMERIC": true,
-                "Isotopes": true,
-                "RGroups": true,
-                "notes": "All other available OESMILESFlag are set to False",
-                "oe_function": "openeye.oechem.OEMolToSmiles",
+                "canonical_SMILES": {
+                    "Flags": [
+                        "DEFAULT",
+                        "Canonical",
+                        "AtomMaps",
+                        "RGroups"
+                    ],
+                    "oe_function": "openeye.oechem.OECreateCanSmiString(molecule)"
+                },
+                "canonical_explicit_hydrogen_SMILES": {
+                    "Flags": [
+                        "Hydrogens",
+                        "Canonical",
+                        "RGroups"
+                    ],
+                    "oe_function": "openeye.oechem.OECreateSmiString()"
+                },
+                "canonical_isomeric_SMILES": {
+                    "Flags": [
+                        "ISOMERIC",
+                        "Isotopes",
+                        "AtomStereo",
+                        "BondStereo",
+                        "Canonical",
+                        "AtomMaps",
+                        "RGroups"
+                    ],
+                    "oe_function": "openeye.oechem.OEMolToSmiles(molecule)"
+                },
+                "canonical_isomeric_explicit_hydrogen_SMILES": {
+                    "Flags": [
+                        "Hydrogens",
+                        "Isotopes",
+                        "AtomStereo",
+                        "BondStereo",
+                        "Canonical",
+                        "RGroups"
+                    ],
+                    "oe_function": "openeye.oechem.OECreateSmiString()"
+                },
+                "notes": "All other available OESMIELSFlag are set to False",
                 "package": "openeye-v2017.Oct.1"
             },
-            "job_id": "b6d0c461f9dd4ab59aa954415d5f432f",
+            "job_id": "b88c52fb-518a-44e9-9495-af3b1ef99339",
             "package": "fragmenter",
             "parent_molecule": "CCCC",
             "routine": "fragmenter.fragment.generate_fragments",
             "routine_options": {
                 "MAX_ROTORS": 2,
-                "OESMILESFlag": "ISOMERIC",
                 "canonicalization": "openeye-v2017.Oct.1",
                 "combinatorial": true,
                 "generate_visualization": false,
-                "inputf": "../../../openforcefield/fragmenter/fragmenter/tests/reference/butane.smi",
-                "json_filename": null,
+                "inputf": "butane.pdb",
+                "json_filename": "butane.json",
                 "remove_map": true,
                 "strict_stereo": true
             },
             "user": "chayastern",
-            "version": "0.0.0+37.gaa58fe7.dirty"
+            "version": "0.0.0+63.g6a300ff.dirty"
         },
         "tagged_SMARTS": "[H:5][C:1]([H:6])([H:7])[C:2]([H:8])([H:9])[C:3]([H:10])([H:11])[C:4]([H:12])([H:13])[H:14]"
     }

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -63,7 +63,7 @@ def fragment_to_torsion_scan(fragments, json_filename=None, grid=30, terminal_to
 
     if json_filename:
         f = open(json_filename, 'w')
-        j = json.dump(molecules, f, indent=4, sort_keys=True, cls=utils.UUIDEncoder)
+        j = json.dump(molecules, f, indent=4, sort_keys=True)
         f.close()
 
     return molecules

--- a/fragmenter/utils.py
+++ b/fragmenter/utils.py
@@ -950,13 +950,6 @@ def log_level(verbose=verbose):
     else:
         return logging.INFO
 
-class UUIDEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, UUID):
-            # if the obj is uuid, we simply return the value of uuid
-            return obj.hex
-        return json.JSONEncoder.default(self, obj)
-
 
 def make_python_identifier(string, namespace=None, reserved_words=None,
                            convert='drop', handle='force'):

--- a/fragmenter/utils.py
+++ b/fragmenter/utils.py
@@ -1074,3 +1074,30 @@ def make_python_identifier(string, namespace=None, reserved_words=None,
     namespace[string] = s
 
     return s, namespace
+
+
+def flatten(l, ltypes=(list, tuple)):
+    """
+    Flatten list of lists
+    Parameters
+    ----------
+    l: list to flatten
+    ltypes: tuple of types
+
+    Returns
+    -------
+    flattened list
+    """
+    ltype = type(l)
+    l = list(l)
+    i = 0
+    while i < len(l):
+        while isinstance(l[i], ltypes):
+            if not l[i]:
+                l.pop(i)
+                i -=1
+                break
+            else:
+                l[i:i + 1] = l[i]
+        i += 1
+    return ltype(l)


### PR DESCRIPTION
## Description
This PR changes the JSON crank spec structure  by separating mid and terminal torsions. The change also allows for different grid options. Below is the JSON spec for `needed_torsion_drives` and `crank_jobs`:

```
"needed_torsions": { 
    "mid": {
        "grid_spacing": [30, 120 ...] # Can also be list of list when specifying more than one crank job
        "torsion_0": (0, 1, 2, 3), 
        "torsion_1": (4, 5, 6 7),
    }
    "terminal": {
        "grid_spacing": None (if we are not driving them)
        "torsion_0": (2, 3, 4, 5)
    }
}
```
```
"crank_job_0": { 
    "mid_torsions" : {
        "torsion_0": 30
        "torsion_1": 120
    "terminal_torsions" : {}
    }
}
```
to specify several 1-D torsion scan:
```
"needed_torsions": { 
    "mid": {
        "grid_spacing": [[30, None, None] , [None, 30, None], [None, None, 30]]
        "torsion_0": (0, 1, 2, 3), 
        "torsion_1": (4, 5, 6 7),
        "torsion_2": (7, 8, 9, 10)
    }
```
