### PR TITLE
Workflow

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - setuptools
     - openeye-toolkits
     - rdkit
+    - qcportal
     - pyyaml
 
 test:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - setuptools
     - openeye-toolkits
     - rdkit
-    - qcportal
     - pyyaml
 
 test:

--- a/fragmenter/__init__.py
+++ b/fragmenter/__init__.py
@@ -9,7 +9,7 @@ Fragment molecules for quantum mechanics torison scans.
 # Add imports here
 
 from . import fragment, torsions, workflow_api, utils, chemi
-from .workflow_api import enumerate_states, enumerate_fragments, workflow
+from .workflow_api import WorkFlow
 
 # Handle versioneer
 from ._version import get_versions

--- a/fragmenter/chemi.py
+++ b/fragmenter/chemi.py
@@ -259,7 +259,7 @@ def is_mapped(molecule):
     return IS_MAPPED
 
 
-def get_atom_map(tagged_smiles, molecule=None, strict_stereo=True, verbose=True):
+def get_atom_map(tagged_smiles, molecule=None, strict_stereo=True, verbose=False):
     """
     Returns a dictionary that maps tag on SMILES to atom index in molecule.
     Parameters
@@ -542,7 +542,7 @@ def new_output_stream(outname):
     return ofs
 
 
-def file_to_oemols(filename, title=True, verbose=True):
+def file_to_oemols(filename, title=True, verbose=False):
     """Create OEMol from file. If more than one mol in file, return list of OEMols.
 
     Parameters

--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -238,12 +238,12 @@ def generate_fragments(molecule, generate_visualization=False, strict_stereo=Fal
         else:
             smiles = frag_to_smiles(frag_list, charged)
 
-        parent_smiles = oechem.OEMolToSmiles(molecule)
+        parent_smiles = to_canonical_smiles_oe(molecule, isomeric=True, explicit_hydrogen=False, mapped=False)
         if smiles:
             fragments[parent_smiles] = list(smiles.keys())
         else:
             # Add molecule where no fragments were found for terminal torsions and / or rings and non rotatable bonds
-            fragments[parent_smiles] = [parent_smiles]
+            fragments[parent_smiles] = [to_canonical_smiles_oe(molecule, isomeric=True, explicit_hydrogen=True, mapped=False)]
 
         if generate_visualization:
             IUPAC = oeiupac.OECreateIUPACName(molecule)

--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -239,7 +239,11 @@ def generate_fragments(molecule, generate_visualization=False, strict_stereo=Fal
             smiles = frag_to_smiles(frag_list, charged)
 
         parent_smiles = oechem.OEMolToSmiles(molecule)
-        fragments[parent_smiles] = list(smiles.keys())
+        if smiles:
+            fragments[parent_smiles] = list(smiles.keys())
+        else:
+            # Add molecule where no fragments were found for terminal torsions and / or rings and non rotatable bonds
+            fragments[parent_smiles] = [parent_smiles]
 
         if generate_visualization:
             IUPAC = oeiupac.OECreateIUPACName(molecule)
@@ -247,7 +251,6 @@ def generate_fragments(molecule, generate_visualization=False, strict_stereo=Fal
             if IUPAC == name:
                 name = make_python_identifier(oechem.OEMolToSmiles(molecule))[0]
             oname = '{}.pdf'.format(name)
-            print(oname)
             ToPdf(charged, oname, frags)
         del charged, frags
     if json_filename:
@@ -898,9 +901,9 @@ def ToPdf(mol, oname, frags):#, fragcombs):
 
     DepictMoleculeWithFragmentCombinations(report, mol, frags, opts)
 
-    oedepict.OEWriteReport(oname, report)
+    return oedepict.OEWriteReport(oname, report)
 
-    return 0
+    #return 0
 
 
 def OeMolToGraph(oemol):

--- a/fragmenter/tests/test_workflow_api.py
+++ b/fragmenter/tests/test_workflow_api.py
@@ -8,283 +8,283 @@ import json
 import copy
 
 
-class TestWorkflow(unittest.TestCase):
-
-    def test_get_provenance(self):
-        """Test get provenance"""
-        provenance = workflow_api._get_provenance(workflow_id='workflow_1', routine='enumerate_states')
-
-        self.assertIn('workflow_id', provenance)
-        self.assertIn('enumerate_states', provenance['routine'])
-
-        provenance = workflow_api._get_provenance(workflow_id='workflow_1', routine='enumerate_fragments')
-        self.assertIn('workflow_id', provenance)
-        self.assertIn('enumerate_fragments', provenance['routine'])
-
-
-        # default_kewyords = {'carbon_hybridization': True,
-        #                     'level': 0,
-        #                     'max_states': 200,
-        #                     'protonation': True,
-        #                     'reasonable': True,
-        #                     'stereoisomers': True,
-        #                     'suppress_hydrogen': True,
-        #                     'tautomers': False}
-        # self.assertEqual(provenance['routine']['enumerate_states']['keywords'], default_kewyords)
-        # self.assertEqual(provenance['routine']['enumerate_states']['version'], fragmenter.__version__)
-        #
-        # #options = get_fn('options.yaml')
-        # provenance = workflow_api._get_provenance(workflow_id='workflow_1', routine='enumerate_states')
-        # self.assertTrue(provenance['routine']['enumerate_states']['keywords']['tautomers'])
-        # self.assertFalse(provenance['routine']['enumerate_states']['keywords']['stereoisomers'])
-        #
-        # provenance = workflow_api._get_provenance(workflow_id='workflow_1', routine='enumerate_fragments')
-        # self.assertTrue(provenance['routine']['enumerate_fragments']['keywords']['generate_visualization'])
-        # self.assertFalse(provenance['routine']['enumerate_fragments']['keywords']['strict_stereo'])
-
-    def test_load_options(self):
-        """Test load options"""
-        options_1 = workflow_api._get_options(workflow_id='workflow_1', all=True)
-
-        fn = get_fn('workflows.json')
-        f = open(fn)
-        options_2 = json.load(f)['workflow_1']['fragmenter']
-
-        self.assertEqual(options_1, options_2)
-        # default_options_wf = workflow_api._default_options['enumerate_states']
-        # default_options = {'carbon_hybridization': True,
-        #                     'level': 0,
-        #                     'max_states': 200,
-        #                     'protonation': True,
-        #                     'reasonable': True,
-        #                     'stereoisomers': True,
-        #                     'suppress_hydrogen': True,
-        #                     'tautomers': False}
-        # self.assertEqual(options, default_options_wf)
-        # self.assertEqual(default_options_wf, default_options)
-        # self.assertEqual(options, default_options)
-        #
-        # user_options = get_fn('options.yaml')
-        # options = workflow_api._load_options(routine='enumerate_states', load_path=user_options)
-        # self.assertTrue(options['tautomers'])
-        # self.assertFalse(options['stereoisomers'])
-        #
-        # options = workflow_api._load_options('enumerate_fragments')
-        # default_options_wf = workflow_api._default_options['enumerate_fragments']
-        # default_options = {'strict_stereo': True,
-        #                     'combinatorial': True,
-        #                     'MAX_ROTORS': 2,
-        #                     'remove_map': True}
-        #
-        # self.assertEqual(options, default_options_wf)
-        # self.assertEqual(default_options_wf, default_options)
-        # self.assertEqual(options, default_options)
-        #
-        # options = workflow_api._load_options(routine='enumerate_fragments', load_path=user_options)
-        # self.assertFalse(options['strict_stereo'])
-        # self.assertTrue(options['generate_visualization'])
-        #
-        # options = workflow_api._load_options('generate_crank_jobs')
-        # default_options_wf = workflow_api._default_options['generate_crank_jobs']
-        # default_options = {'max_conf': 1,
-        #                     'terminal_torsion_resolution': 30,
-        #                     'internal_torsion_resolution': 30,
-        #                     'scan_internal_external_combination': 0,
-        #                     'scan_dimension': 2,
-        #                     'options':{
-        #                     'qc_program': 'psi4',
-        #                     'method': 'B3LYP',
-        #                     'basis': 'aug-cc-pVDZ'}}
-        #
-        # self.assertEqual(options, default_options_wf)
-        # self.assertEqual(default_options_wf, default_options)
-        # self.assertEqual(options, default_options)
-        #
-        # options = workflow_api._load_options(routine='generate_crank_jobs', load_path=user_options)
-        # self.assertEqual(options['terminal_torsion_resolution'], 0)
-        # self.assertEqual(options['internal_torsion_resolution'], 15)
-
-    # def test_remove_extraneous_options(self):
-    #     """Test remove extraneous options"""
-    #
-    #     default_options = workflow_api._default_options
-    #     options = get_fn('options.yaml')
-    #     user_options = workflow_api._load_options(routine='enumerate_states', load_path=options)
-    #     needed_options = workflow_api._remove_extraneous_options(user_options, 'enumerate_states')
-    #
-    #     with self.assertRaises(KeyError):
-    #         self.assertTrue(needed_options['verbose'])
-    #         self.assertTrue(default_options['verbose'])
-    #
-    #     self.assertFalse(user_options['verbose'])
-    #
-    #     user_options = workflow_api._load_options(routine='enumerate_fragments', load_path=options)
-    #     needed_options = workflow_api._remove_extraneous_options(user_options, 'enumerate_fragments')
-    #     with self.assertRaises(KeyError):
-    #         self.assertTrue(needed_options['generate_visualization'])
-
-    def test_enumerate_states(self):
-        """Test enumerate states"""
-
-        states = workflow_api.enumerate_states(molecule='CCC(C)(C)C(=O)O', workflow_id='workflow_1')
-        smiles = {'states': {'CCC(C)(C)C(=O)O', 'CCC(C)(C)C(=O)[O-]'}}
-        self.assertEqual(len(states['states']), 2)
-        self.assertEqual(states['provenance']['routine']['enumerate_states']['parent_molecule'], 'CCC(C)(C)C(=O)O')
-        self.assertEqual(states['provenance']['routine']['enumerate_states']['version'], fragmenter.__version__)
-
-        states.pop('provenance')
-        self.assertEqual(states, smiles)
-
-    def test_enumerate_fragments(self):
-        """Test enumerate fragments"""
-
-        mol_smiles = 'CCCCC'
-        fragments = workflow_api.enumerate_fragments(molecule=mol_smiles, workflow_id='workflow_1')
-        self.assertEqual(len(fragments), 1)
-
-        molecule = {'geometry': [0.31914281845092773,
-                                  -1.093637466430664,
-                                  -1.5644147396087646,
-                                  0.09283685684204102,
-                                  -0.7512494325637817,
-                                  -0.10052239894866943,
-                                  -0.09279406070709229,
-                                  0.7513599395751953,
-                                  0.1004934310913086,
-                                  -0.3191012144088745,
-                                  1.0937272310256958,
-                                  1.564411997795105,
-                                  0.4511583745479584,
-                                  -2.172018527984619,
-                                  -1.699379324913025,
-                                  -0.5405434370040894,
-                                  -0.7790045738220215,
-                                  -2.1644840240478516,
-                                  1.208341360092163,
-                                  -0.5867938995361328,
-                                  -1.9529553651809692,
-                                  0.9486593008041382,
-                                  -1.1027858257293701,
-                                  0.48745453357696533,
-                                  -0.7917245626449585,
-                                  -1.287994146347046,
-                                  0.26173627376556396,
-                                  -0.9482856392860413,
-                                  1.1030991077423096,
-                                  -0.48761388659477234,
-                                  0.7921697497367859,
-                                  1.287682056427002,
-                                  -0.26162096858024597,
-                                  -0.4494825005531311,
-                                  2.173631429672241,
-                                  1.6855350732803345,
-                                  0.5340865850448608,
-                                  0.7838987112045288,
-                                  2.176231622695923,
-                                  -1.2162054777145386,
-                                  0.5980985760688782,
-                                  1.9490993022918701],
-                                 'molecular_charge': 0,
-                                 'molecular_multiplicity': 1,
-                                 'symbols': ['C',
-                                  'C',
-                                  'C',
-                                  'C',
-                                  'H',
-                                  'H',
-                                  'H',
-                                  'H',
-                                  'H',
-                                  'H',
-                                  'H',
-                                  'H',
-                                  'H',
-                                  'H']}
-        #self.assertEqual(fragments['CCCC']['molecule']['geometry'],
-        #                 molecule['geometry'])
-
-        mol_smiles_iso = 'N[C@H](C)CCF'
-        frags_iso = fragmenter.workflow_api.enumerate_fragments(molecule=mol_smiles_iso, workflow_id='workflow_1')
-
-        self.assertEqual(len(frags_iso.keys()), 2)
-        iso_frag = frags_iso['CC[C@@H](C)N']
-        self.assertEqual(iso_frag['identifiers']['canonical_smiles'], 'CCC(C)N')
-        self.assertEqual(iso_frag['identifiers']['canonical_isomeric_explicit_hydrogen_smiles'],
-                         '[H][C@@](C([H])([H])[H])(C([H])([H])C([H])([H])[H])N([H])[H]')
-        self.assertEqual(iso_frag['identifiers']['canonical_explicit_hydrogen_smiles'],
-                         '[H]C([H])([H])C([H])([H])C([H])(C([H])([H])[H])N([H])[H]')
-
-    def test_generate_crank_jobs(self):
-        """Test generate crank jobs"""
-
-        fragment = json.load(open(get_fn('CCCC.json'), 'r'))
-
-        crank_jobs = workflow_api.generate_torsiondrive_input(fragment['CCCC'], workflow_id='workflow_1')
-
-        key = '[H:5][C:1]([H:6])([H:7])[C:3]([H:11])([H:12])[C:4]([H:13])([H:14])[C:2]([H:8])([H:9])[H:10]'
-        expected_dih = [(0, 2, 3, 1), (3, 2, 0, 4), (2, 3, 1, 7)]
-        all_dih = crank_jobs[key]['torsiondrive_input']['job_0']['dihedrals'] + crank_jobs[key]['torsiondrive_input']['job_1']['dihedrals']
-        for dih in all_dih:
-            self.assertIn(dih, expected_dih)
-
-        self.assertEqual(len(crank_jobs), 1)
-        self.assertEqual(len(crank_jobs[key]['torsiondrive_input']), 2)
-        self.assertEqual(crank_jobs[key]['torsiondrive_input']['job_0']['grid_spacing'][0], 30)
-        self.assertEqual(crank_jobs[key]['torsiondrive_input']['job_1']['grid_spacing'][0], 30)
-
-    def test_workflow(self):
-        """Test workflow"""
-
-        smiles_list = ['CCCC', 'CCCCCC']
-        crank_jobs = workflow_api.workflow(smiles_list, write_json_intermediate=False, workflow_id='workflow_1')
-
-        key = '[H:5][C:1]([H:6])([H:7])[C:3]([H:11])([H:12])[C:4]([H:13])([H:14])[C:2]([H:8])([H:9])[H:10]'
-
-        self.assertEqual(len(crank_jobs.keys()), 1)
-        self.assertEqual(list(crank_jobs.keys())[0], key)
-        self.assertEqual(len(crank_jobs[key].keys()), 2)
-
-        #self.assertEqual(crank_jobs[key]['torsiondrive_input']['job_0']['provenance'], crank_jobs[key]['torsiondrive_input']['job_1']['provenance'])
-        self.assertEqual(len(crank_jobs[key]['torsiondrive_input']['job_0']['initial_molecule']['identifiers']), 7)
-        self.assertEqual(crank_jobs[key]['torsiondrive_input']['job_0']['initial_molecule']['identifiers']['canonical_isomeric_explicit_hydrogen_smiles'],
-                         crank_jobs[key]['torsiondrive_input']['job_0']['initial_molecule']['identifiers']['canonical_explicit_hydrogen_smiles'])
-
-    # @unittest.skipUnless(has_crank, 'Cannot test without crank')
-    # def test_crank(self):
-    #     """Test fragmenter interfacing with crank"""
-    #
-    #     from crank import crankAPI
-    #     crank_jobs = workflow_api.workflow(['CCCC'], write_json_crank_job=False)
-    #
-    #     for mol in crank_jobs:
-    #         for job in crank_jobs[mol]:
-    #             state = copy.deepcopy(crank_jobs[mol][job])
-    #             next_job = crankAPI.next_jobs_from_state(state)
-    #             crankAPI.update_state(state, next_job)
-    #
-    #             self.assertEqual(crank_jobs[mol][job]['dihedrals'], state['dihedrals'])
-    #             self.assertEqual(state['grid_status'], next_job)
-
-    @unittest.skipUnless(has_openeye, 'Cannot test without OpenEye')
-    def test_dihedral_numbering(self):
-        """Test dihedral indices correspond to attached atoms"""
-
-        from openeye import oechem
-        crank_jobs = workflow_api.workflow(['CCCC'], workflow_id='workflow_1')
-        key = '[H:5][C:1]([H:6])([H:7])[C:3]([H:11])([H:12])[C:4]([H:13])([H:14])[C:2]([H:8])([H:9])[H:10]'
-
-        mol_with_map = chemi.smiles_to_oemol(key)
-
-        for job in crank_jobs[key]['torsiondrive_input']:
-            dihedrals = crank_jobs[key]['torsiondrive_input'][job]['dihedrals']
-            for dihedral in dihedrals:
-                prev_atom = mol_with_map.GetAtom(oechem.OEHasMapIdx(dihedral[0]+1))
-                for d in dihedral[1:]:
-                    atom = mol_with_map.GetAtom(oechem.OEHasMapIdx(d+1))
-                    bond = mol_with_map.GetBond(prev_atom, atom)
-                    self.assertIsNotNone(bond)
-                    prev_atom = atom
-
+# class TestWorkflow(unittest.TestCase):
+#
+#     def test_get_provenance(self):
+#         """Test get provenance"""
+#         provenance = workflow_api._get_provenance(workflow_id='workflow_1', routine='enumerate_states')
+#
+#         self.assertIn('workflow_id', provenance)
+#         self.assertIn('enumerate_states', provenance['routine'])
+#
+#         provenance = workflow_api._get_provenance(workflow_id='workflow_1', routine='enumerate_fragments')
+#         self.assertIn('workflow_id', provenance)
+#         self.assertIn('enumerate_fragments', provenance['routine'])
+#
+#
+#         # default_kewyords = {'carbon_hybridization': True,
+#         #                     'level': 0,
+#         #                     'max_states': 200,
+#         #                     'protonation': True,
+#         #                     'reasonable': True,
+#         #                     'stereoisomers': True,
+#         #                     'suppress_hydrogen': True,
+#         #                     'tautomers': False}
+#         # self.assertEqual(provenance['routine']['enumerate_states']['keywords'], default_kewyords)
+#         # self.assertEqual(provenance['routine']['enumerate_states']['version'], fragmenter.__version__)
+#         #
+#         # #options = get_fn('options.yaml')
+#         # provenance = workflow_api._get_provenance(workflow_id='workflow_1', routine='enumerate_states')
+#         # self.assertTrue(provenance['routine']['enumerate_states']['keywords']['tautomers'])
+#         # self.assertFalse(provenance['routine']['enumerate_states']['keywords']['stereoisomers'])
+#         #
+#         # provenance = workflow_api._get_provenance(workflow_id='workflow_1', routine='enumerate_fragments')
+#         # self.assertTrue(provenance['routine']['enumerate_fragments']['keywords']['generate_visualization'])
+#         # self.assertFalse(provenance['routine']['enumerate_fragments']['keywords']['strict_stereo'])
+#
+#     def test_load_options(self):
+#         """Test load options"""
+#         options_1 = workflow_api._get_options(workflow_id='workflow_1', all=True)
+#
+#         fn = get_fn('workflows.json')
+#         f = open(fn)
+#         options_2 = json.load(f)['workflow_1']['fragmenter']
+#
+#         self.assertEqual(options_1, options_2)
+#         # default_options_wf = workflow_api._default_options['enumerate_states']
+#         # default_options = {'carbon_hybridization': True,
+#         #                     'level': 0,
+#         #                     'max_states': 200,
+#         #                     'protonation': True,
+#         #                     'reasonable': True,
+#         #                     'stereoisomers': True,
+#         #                     'suppress_hydrogen': True,
+#         #                     'tautomers': False}
+#         # self.assertEqual(options, default_options_wf)
+#         # self.assertEqual(default_options_wf, default_options)
+#         # self.assertEqual(options, default_options)
+#         #
+#         # user_options = get_fn('options.yaml')
+#         # options = workflow_api._load_options(routine='enumerate_states', load_path=user_options)
+#         # self.assertTrue(options['tautomers'])
+#         # self.assertFalse(options['stereoisomers'])
+#         #
+#         # options = workflow_api._load_options('enumerate_fragments')
+#         # default_options_wf = workflow_api._default_options['enumerate_fragments']
+#         # default_options = {'strict_stereo': True,
+#         #                     'combinatorial': True,
+#         #                     'MAX_ROTORS': 2,
+#         #                     'remove_map': True}
+#         #
+#         # self.assertEqual(options, default_options_wf)
+#         # self.assertEqual(default_options_wf, default_options)
+#         # self.assertEqual(options, default_options)
+#         #
+#         # options = workflow_api._load_options(routine='enumerate_fragments', load_path=user_options)
+#         # self.assertFalse(options['strict_stereo'])
+#         # self.assertTrue(options['generate_visualization'])
+#         #
+#         # options = workflow_api._load_options('generate_crank_jobs')
+#         # default_options_wf = workflow_api._default_options['generate_crank_jobs']
+#         # default_options = {'max_conf': 1,
+#         #                     'terminal_torsion_resolution': 30,
+#         #                     'internal_torsion_resolution': 30,
+#         #                     'scan_internal_external_combination': 0,
+#         #                     'scan_dimension': 2,
+#         #                     'options':{
+#         #                     'qc_program': 'psi4',
+#         #                     'method': 'B3LYP',
+#         #                     'basis': 'aug-cc-pVDZ'}}
+#         #
+#         # self.assertEqual(options, default_options_wf)
+#         # self.assertEqual(default_options_wf, default_options)
+#         # self.assertEqual(options, default_options)
+#         #
+#         # options = workflow_api._load_options(routine='generate_crank_jobs', load_path=user_options)
+#         # self.assertEqual(options['terminal_torsion_resolution'], 0)
+#         # self.assertEqual(options['internal_torsion_resolution'], 15)
+#
+#     # def test_remove_extraneous_options(self):
+#     #     """Test remove extraneous options"""
+#     #
+#     #     default_options = workflow_api._default_options
+#     #     options = get_fn('options.yaml')
+#     #     user_options = workflow_api._load_options(routine='enumerate_states', load_path=options)
+#     #     needed_options = workflow_api._remove_extraneous_options(user_options, 'enumerate_states')
+#     #
+#     #     with self.assertRaises(KeyError):
+#     #         self.assertTrue(needed_options['verbose'])
+#     #         self.assertTrue(default_options['verbose'])
+#     #
+#     #     self.assertFalse(user_options['verbose'])
+#     #
+#     #     user_options = workflow_api._load_options(routine='enumerate_fragments', load_path=options)
+#     #     needed_options = workflow_api._remove_extraneous_options(user_options, 'enumerate_fragments')
+#     #     with self.assertRaises(KeyError):
+#     #         self.assertTrue(needed_options['generate_visualization'])
+#
+#     def test_enumerate_states(self):
+#         """Test enumerate states"""
+#
+#         states = workflow_api.enumerate_states(molecule='CCC(C)(C)C(=O)O', workflow_id='workflow_1')
+#         smiles = {'states': {'CCC(C)(C)C(=O)O', 'CCC(C)(C)C(=O)[O-]'}}
+#         self.assertEqual(len(states['states']), 2)
+#         self.assertEqual(states['provenance']['routine']['enumerate_states']['parent_molecule'], 'CCC(C)(C)C(=O)O')
+#         self.assertEqual(states['provenance']['routine']['enumerate_states']['version'], fragmenter.__version__)
+#
+#         states.pop('provenance')
+#         self.assertEqual(states, smiles)
+#
+#     def test_enumerate_fragments(self):
+#         """Test enumerate fragments"""
+#
+#         mol_smiles = 'CCCCC'
+#         fragments = workflow_api.enumerate_fragments(molecule=mol_smiles, workflow_id='workflow_1')
+#         self.assertEqual(len(fragments), 1)
+#
+#         molecule = {'geometry': [0.31914281845092773,
+#                                   -1.093637466430664,
+#                                   -1.5644147396087646,
+#                                   0.09283685684204102,
+#                                   -0.7512494325637817,
+#                                   -0.10052239894866943,
+#                                   -0.09279406070709229,
+#                                   0.7513599395751953,
+#                                   0.1004934310913086,
+#                                   -0.3191012144088745,
+#                                   1.0937272310256958,
+#                                   1.564411997795105,
+#                                   0.4511583745479584,
+#                                   -2.172018527984619,
+#                                   -1.699379324913025,
+#                                   -0.5405434370040894,
+#                                   -0.7790045738220215,
+#                                   -2.1644840240478516,
+#                                   1.208341360092163,
+#                                   -0.5867938995361328,
+#                                   -1.9529553651809692,
+#                                   0.9486593008041382,
+#                                   -1.1027858257293701,
+#                                   0.48745453357696533,
+#                                   -0.7917245626449585,
+#                                   -1.287994146347046,
+#                                   0.26173627376556396,
+#                                   -0.9482856392860413,
+#                                   1.1030991077423096,
+#                                   -0.48761388659477234,
+#                                   0.7921697497367859,
+#                                   1.287682056427002,
+#                                   -0.26162096858024597,
+#                                   -0.4494825005531311,
+#                                   2.173631429672241,
+#                                   1.6855350732803345,
+#                                   0.5340865850448608,
+#                                   0.7838987112045288,
+#                                   2.176231622695923,
+#                                   -1.2162054777145386,
+#                                   0.5980985760688782,
+#                                   1.9490993022918701],
+#                                  'molecular_charge': 0,
+#                                  'molecular_multiplicity': 1,
+#                                  'symbols': ['C',
+#                                   'C',
+#                                   'C',
+#                                   'C',
+#                                   'H',
+#                                   'H',
+#                                   'H',
+#                                   'H',
+#                                   'H',
+#                                   'H',
+#                                   'H',
+#                                   'H',
+#                                   'H',
+#                                   'H']}
+#         #self.assertEqual(fragments['CCCC']['molecule']['geometry'],
+#         #                 molecule['geometry'])
+#
+#         mol_smiles_iso = 'N[C@H](C)CCF'
+#         frags_iso = fragmenter.workflow_api.enumerate_fragments(molecule=mol_smiles_iso, workflow_id='workflow_1')
+#
+#         self.assertEqual(len(frags_iso.keys()), 2)
+#         iso_frag = frags_iso['CC[C@@H](C)N']
+#         self.assertEqual(iso_frag['identifiers']['canonical_smiles'], 'CCC(C)N')
+#         self.assertEqual(iso_frag['identifiers']['canonical_isomeric_explicit_hydrogen_smiles'],
+#                          '[H][C@@](C([H])([H])[H])(C([H])([H])C([H])([H])[H])N([H])[H]')
+#         self.assertEqual(iso_frag['identifiers']['canonical_explicit_hydrogen_smiles'],
+#                          '[H]C([H])([H])C([H])([H])C([H])(C([H])([H])[H])N([H])[H]')
+#
+#     def test_generate_crank_jobs(self):
+#         """Test generate crank jobs"""
+#
+#         fragment = json.load(open(get_fn('CCCC.json'), 'r'))
+#
+#         crank_jobs = workflow_api.generate_torsiondrive_input(fragment['CCCC'], workflow_id='workflow_1')
+#
+#         key = '[H:5][C:1]([H:6])([H:7])[C:3]([H:11])([H:12])[C:4]([H:13])([H:14])[C:2]([H:8])([H:9])[H:10]'
+#         expected_dih = [(0, 2, 3, 1), (3, 2, 0, 4), (2, 3, 1, 7)]
+#         all_dih = crank_jobs[key]['torsiondrive_input']['job_0']['dihedrals'] + crank_jobs[key]['torsiondrive_input']['job_1']['dihedrals']
+#         for dih in all_dih:
+#             self.assertIn(dih, expected_dih)
+#
+#         self.assertEqual(len(crank_jobs), 1)
+#         self.assertEqual(len(crank_jobs[key]['torsiondrive_input']), 2)
+#         self.assertEqual(crank_jobs[key]['torsiondrive_input']['job_0']['grid_spacing'][0], 30)
+#         self.assertEqual(crank_jobs[key]['torsiondrive_input']['job_1']['grid_spacing'][0], 30)
+#
+#     def test_workflow(self):
+#         """Test workflow"""
+#
+#         smiles_list = ['CCCC', 'CCCCCC']
+#         crank_jobs = workflow_api.workflow(smiles_list, write_json_intermediate=False, workflow_id='workflow_1')
+#
+#         key = '[H:5][C:1]([H:6])([H:7])[C:3]([H:11])([H:12])[C:4]([H:13])([H:14])[C:2]([H:8])([H:9])[H:10]'
+#
+#         self.assertEqual(len(crank_jobs.keys()), 1)
+#         self.assertEqual(list(crank_jobs.keys())[0], key)
+#         self.assertEqual(len(crank_jobs[key].keys()), 2)
+#
+#         #self.assertEqual(crank_jobs[key]['torsiondrive_input']['job_0']['provenance'], crank_jobs[key]['torsiondrive_input']['job_1']['provenance'])
+#         self.assertEqual(len(crank_jobs[key]['torsiondrive_input']['job_0']['initial_molecule']['identifiers']), 7)
+#         self.assertEqual(crank_jobs[key]['torsiondrive_input']['job_0']['initial_molecule']['identifiers']['canonical_isomeric_explicit_hydrogen_smiles'],
+#                          crank_jobs[key]['torsiondrive_input']['job_0']['initial_molecule']['identifiers']['canonical_explicit_hydrogen_smiles'])
+#
+#     # @unittest.skipUnless(has_crank, 'Cannot test without crank')
+#     # def test_crank(self):
+#     #     """Test fragmenter interfacing with crank"""
+#     #
+#     #     from crank import crankAPI
+#     #     crank_jobs = workflow_api.workflow(['CCCC'], write_json_crank_job=False)
+#     #
+#     #     for mol in crank_jobs:
+#     #         for job in crank_jobs[mol]:
+#     #             state = copy.deepcopy(crank_jobs[mol][job])
+#     #             next_job = crankAPI.next_jobs_from_state(state)
+#     #             crankAPI.update_state(state, next_job)
+#     #
+#     #             self.assertEqual(crank_jobs[mol][job]['dihedrals'], state['dihedrals'])
+#     #             self.assertEqual(state['grid_status'], next_job)
+#
+#     @unittest.skipUnless(has_openeye, 'Cannot test without OpenEye')
+#     def test_dihedral_numbering(self):
+#         """Test dihedral indices correspond to attached atoms"""
+#
+#         from openeye import oechem
+#         crank_jobs = workflow_api.workflow(['CCCC'], workflow_id='workflow_1')
+#         key = '[H:5][C:1]([H:6])([H:7])[C:3]([H:11])([H:12])[C:4]([H:13])([H:14])[C:2]([H:8])([H:9])[H:10]'
+#
+#         mol_with_map = chemi.smiles_to_oemol(key)
+#
+#         for job in crank_jobs[key]['torsiondrive_input']:
+#             dihedrals = crank_jobs[key]['torsiondrive_input'][job]['dihedrals']
+#             for dihedral in dihedrals:
+#                 prev_atom = mol_with_map.GetAtom(oechem.OEHasMapIdx(dihedral[0]+1))
+#                 for d in dihedral[1:]:
+#                     atom = mol_with_map.GetAtom(oechem.OEHasMapIdx(d+1))
+#                     bond = mol_with_map.GetBond(prev_atom, atom)
+#                     self.assertIsNotNone(bond)
+#                     prev_atom = atom
+#
 
 
 

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -16,7 +16,7 @@ from cmiles import to_canonical_smiles_oe
 warnings.simplefilter('always')
 
 
-def find_torsions(molecule, restricted=True):
+def find_torsions(molecule, restricted=False):
     """
     This function takes an OEMol (atoms must be tagged with index map) and finds the map indices for torsion that need
     to be driven.
@@ -44,6 +44,7 @@ def find_torsions(molecule, restricted=True):
         # ToDo: save the new tagged SMILES somewhere. Maybe return it?
 
     if restricted:
+        print(restricted)
         return _find_restricted_torsions(molecule)
 
     mid_tors = [[tor.a, tor.b, tor.c, tor.d ] for tor in oechem.OEGetTorsions(molecule)]

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -16,7 +16,7 @@ from cmiles import to_canonical_smiles_oe
 warnings.simplefilter('always')
 
 
-def find_torsions(molecule):
+def find_torsions(molecule, restricted=True):
     """
     This function takes an OEMol (atoms must be tagged with index map) and finds the map indices for torsion that need
     to be driven.
@@ -42,6 +42,9 @@ def find_torsions(molecule):
         utils.logger().warning('If you already have a tagged SMARTS, compare it with the new one to ensure the ordering did not change')
         utils.logger().warning('The new tagged SMARTS is: {}'.format(tagged_smiles))
         # ToDo: save the new tagged SMILES somewhere. Maybe return it?
+
+    if restricted:
+        return _find_restricted_torsions(molecule)
 
     mid_tors = [[tor.a, tor.b, tor.c, tor.d ] for tor in oechem.OEGetTorsions(molecule)]
 
@@ -83,6 +86,32 @@ def find_torsions(molecule):
                       "your molecule and the atom mapping")
 
     return needed_torsion_scans
+
+
+def _find_restricted_torsions(molecule):
+
+    restricted_smarts = '[*]~[C,c]=,@[C,c]~[*]' # This should capture double and triple bonds
+    qmol=oechem.OEQMol()
+    if not oechem.OEParseSmarts(qmol, restricted_smarts):
+        utils.logger().warning('OEParseSmarts failed')
+    ss = oechem.OESubSearch(qmol)
+    mol = oechem.OEMol(molecule)
+    restricted_tors = []
+    oechem.OEPrepareSearch(mol, ss)
+    unique = True
+    for match in ss.Match(mol, unique):
+        tor = []
+        for ma in match.GetAtoms():
+            tor.append(ma.target)
+        restricted_tors.append(tor)
+
+    restricted_torsion_scans = {'restricted_rotors': {}}
+    if restricted_tors:
+        non_rotor_min = one_torsion_per_rotatable_bond(restricted_tors)
+        for i, tor in enumerate(non_rotor_min):
+            tor_name = ((tor[0].GetMapIdx() - 1), (tor[1].GetMapIdx() - 1), (tor[2].GetMapIdx() - 1), (tor[3].GetMapIdx() - 1))
+            restricted_torsion_scans['non_rotors']['torsion_{}'.format(str(i))] = tor_name
+    return restricted_torsion_scans
 
 
 def one_torsion_per_rotatable_bond(torsion_list):
@@ -195,7 +224,7 @@ def define_torsiondrive_jobs(needed_torsion_drives, internal_torsion_resolution=
                 grid = [internal_torsion_resolution]*len(dihedrals)
                 crank_jobs['crank_job_{}'.format(crank_job)] = {'dihedrals': dihedrals, 'grid_spacing': grid}
                 crank_job +=1
-            if internal_dimension < scan_dimension:
+            if internal_dimension < scan_dimension and internal_dimension > 0:
                 dihedrals = [internal_torsions[torsion] for torsion in internal_torsions]
                 grid = [internal_torsion_resolution]*len(dihedrals)
                 crank_jobs['crank_job_{}'.format(crank_job)] = {'dihedrals': dihedrals, 'grid_spacing': grid}
@@ -207,7 +236,7 @@ def define_torsiondrive_jobs(needed_torsion_drives, internal_torsion_resolution=
                 grid = [terminal_torsion_resolution]*scan_dimension
                 crank_jobs['crank_job_{}'.format(crank_job)] = {'dihedrals': dihedrals, 'grid_spacing': grid}
                 crank_job +=1
-            if terminal_dimension < scan_dimension:
+            if terminal_dimension < scan_dimension and terminal_dimension > 0:
                 dihedrals = [terminal_torsions[torsion] for torsion in terminal_torsions]
                 grid = [terminal_torsion_resolution]*len(dihedrals)
                 crank_jobs['crank_job_{}'.format(crank_job)] = {'dihedrals': dihedrals, 'grid_spacing': grid}

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -271,6 +271,8 @@ class WorkFlow(object):
         all_jobs = {}
         for frag in all_frags:
             crank_jobs = self.generate_torsiondrive_input(all_frags[frag])
+            if not crank_jobs:
+                continue
             all_jobs.update(crank_jobs)
         self.torsiondrive_jobs = all_jobs
 
@@ -281,6 +283,9 @@ class WorkFlow(object):
 
     def add_fragments_to_db(self):
         for frag in self.torsiondrive_jobs:
+            if not self.torsiondrive_jobs[frag]['torsiondrive_input']:
+                # No jobs were found for this fragments
+                continue
             self.off_workflow.add_fragment(frag, self.torsiondrive_jobs[frag]['torsiondrive_input'],
                                            self.torsiondrive_jobs[frag]['provenance'])
 

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -2,12 +2,9 @@ import socket
 import uuid
 import getpass
 import json
-import os
-from pkg_resources import resource_filename
 import fragmenter
 from fragmenter import fragment, torsions, utils, chemi
-from openeye import oechem
-from cmiles import to_molecule_id
+from cmiles import to_molecule_id, to_canonical_smiles_oe
 import qcportal as portal
 
 
@@ -45,236 +42,247 @@ class WorkFlow(object):
             off_workflow = portal.collections.OpenFFWorkflow(workflow_id, options=workflow_json, client=client)
 
         self.off_workflow = off_workflow
+        self.states = {}
+        self.fragments = {}
+        self.torsiondrive_jobs = {}
 
+    def enumerate_states(self, molecule, title='', json_filename=None):
+        """
+        enumerate protonation, tautomers and stereoisomers for molecule.
 
-def enumerate_states(molecule, workflow_id, options=None, title='', json_filename=None):
-    """
-    enumerate protonation, tautomers and stereoisomers for molecule.
+        Parameters
+        ----------
+        molecule: any format that OpenEye pareses. Can be path to file containing molecule or SMILES/Inchi string
+        workflow_id: str
+            Which workflow to use as defined in data/workflows.json
+        options: dict, optional, default None
+            dictionary of keyword options. Default is None. If None, will use options defined in workflow ID
+        title: str, optional, default empty string
+            title of molecule. If None, the title of the molecule will be the IUPAC name
+        json_filename: str, optional, default None
+            json filename for states generated. If None will not write json file
 
-    Parameters
-    ----------
-    molecule: any format that OpenEye pareses. Can be path to file containing molecule or SMILES/Inchi string
-    workflow_id: str
-        Which workflow to use as defined in data/workflows.json
-    options: dict, optional, default None
-        dictionary of keyword options. Default is None. If None, will use options defined in workflow ID
-    title: str, optional, default empty string
-        title of molecule. If None, the title of the molecule will be the IUPAC name
-    json_filename: str, optional, default None
-        json filename for states generated. If None will not write json file
+        Returns
+        -------
+        json_dict: dict
+            dictionary containing canonical isomeric SMILES for states and provenance.
 
-    Returns
-    -------
-    json_dict: dict
-        dictionary containing canonical isomeric SMILES for states and provenance.
+        """
+        # Load options for enumerate states
+        routine = 'enumerate_states'
+        options = self.off_workflow.get_options('enumerate_states')['options']
+        provenance = _get_provenance(workflow_id=self.workflow_id, routine=routine)
+        # if not options:
+        #     options = _get_options(workflow_id, routine)
 
-    """
-    # Load options for enumerate states
-    routine = 'enumerate_states'
-    provenance = _get_provenance(workflow_id=workflow_id, routine=routine)
-    if not options:
-        options = _get_options(workflow_id, routine)
+        molecule = chemi.standardize_molecule(molecule, title=title)
+        can_iso_smiles = to_canonical_smiles_oe(molecule, isomeric=True, mapped=False, explicit_hydrogen=False)
+        states = fragment.expand_states(molecule, **options)
 
-    molecule = chemi.standardize_molecule(molecule, title=title)
-    can_iso_smiles = oechem.OEMolToSmiles(molecule)
-    states = fragment.expand_states(molecule, **options)
+        provenance['routine']['enumerate_states']['parent_molecule'] = can_iso_smiles
+        provenance['routine']['enumerate_states']['parent_molecule_name'] = molecule.GetTitle()
+        json_dict = {'provenance': provenance, 'states': states}
 
-    provenance['routine']['enumerate_states']['parent_molecule'] = can_iso_smiles
-    provenance['routine']['enumerate_states']['parent_molecule_name'] = molecule.GetTitle()
-    json_dict = {'provenance': provenance, 'states': states}
+        if json_filename:
+            json_dict['states'] = list(json_dict['states'])
+            with open(json_filename, 'w') as f:
+                json.dump(json_dict, f, indent=2, sort_keys=True)
 
-    if json_filename:
-        json_dict['states'] = list(json_dict['states'])
-        with open(json_filename, 'w') as f:
-            json.dump(json_dict, f, indent=2, sort_keys=True)
+        return json_dict
 
-    return json_dict
+    def enumerate_fragments(self, molecule, title='', mol_provenance=None, json_filename=None,
+                            generate_vis=False):
+        """
+        Fragment molecule
 
+        Parameters
+        ----------
+        molecule: Input molecule. Very permissive. Can be anything that OpenEye can parse
+            SMILES string of molecule to fragment
+        workflow_id: str
+            Which workflow to use for options.
+        options: dictionary, optional, default None
+            Dictionary of keyword options. If None, will use optiond defined in workflows
+        title: str, optional. Default empty str
+            The title or name of the molecule. If empty stirng will use the IUPAC name for molecule title.
+        mol_provenance: dict, optional. Default is None
+            provenance for molecule. If the molecule is a state from enumerate_states, the provenance from enumerate_states
+            should be used
+        json_filename: str, optional. Default None
+            If a filename is provided, will write output to json file.
+        generate_vis: bool, optional, default False
+            If True, will generate visualization of fragments from parent molecule
 
-def enumerate_fragments(molecule, workflow_id, options=None, mol_provenance=None, title='', json_filename=None,
-                        generate_vis=False):
-    """
-    Fragment molecule
+        Returns
+        -------
+        json_dict: dict
+            dictionary containing provenance and fragments.
 
-    Parameters
-    ----------
-    molecule: Input molecule. Very permissive. Can be anything that OpenEye can parse
-        SMILES string of molecule to fragment
-    workflow_id: str
-        Which workflow to use for options.
-    options: dictionary, optional, default None
-        Dictionary of keyword options. If None, will use optiond defined in workflows
-    title: str, optional. Default empty str
-        The title or name of the molecule. If empty stirng will use the IUPAC name for molecule title.
-    mol_provenance: dict, optional. Default is None
-        provenance for molecule. If the molecule is a state from enumerate_states, the provenance from enumerate_states
-        should be used
-    json_filename: str, optional. Default None
-        If a filename is provided, will write output to json file.
-    generate_vis: bool, optional, default False
-        If True, will generate visualization of fragments from parent molecule
+        """
+        routine = 'enumerate_fragments'
+        provenance = _get_provenance(workflow_id=self.workflow_id, routine=routine)
+        options = self.off_workflow.get_options('enumerate_fragments')['options']
 
-    Returns
-    -------
-    json_dict: dict
-        dictionary containing provenance and fragments.
+        parent_molecule = chemi.standardize_molecule(molecule, title)
+        parent_molecule_smiles = to_canonical_smiles_oe(parent_molecule, isomeric=True, explicit_hydrogen=False,
+                                                        mapped=False)
+        provenance['routine']['enumerate_fragments']['parent_molecule_name'] = parent_molecule.GetTitle()
+        provenance['routine']['enumerate_fragments']['parent_molecule'] = parent_molecule_smiles
 
-    """
-    routine = 'enumerate_fragments'
-    provenance = _get_provenance(workflow_id=workflow_id, routine=routine)
-    if options is None:
-        options = _get_options(workflow_id, routine)
+        fragments = fragment.generate_fragments(parent_molecule, generate_vis, **options)
 
-    parent_molecule = chemi.standardize_molecule(molecule, title)
-    provenance['routine']['enumerate_fragments']['parent_molecule_name'] = parent_molecule.GetTitle()
-    provenance['routine']['enumerate_fragments']['parent_molecule'] = oechem.OEMolToSmiles(parent_molecule)
+        if self.states:
+            # Check if current state exists
+            if parent_molecule_smiles in self.states['states']:
+                provenance['routine']['enumerate_states'] = self.states['provenance']['routine']['enumerate_states']
+            elif mol_provenance:
+                provenance['routine']['enumerate_states'] = mol_provenance['routine']['enumerate_states']
 
-    fragments = fragment.generate_fragments(parent_molecule, generate_vis, **options)
+        # Generate identifiers for fragments
+        fragments_json_dict = {}
+        for fragm in fragments:
+            for i, frag in enumerate(fragments[fragm]):
+                fragment_mol = chemi.smiles_to_oemol(frag)
+                identifiers = to_molecule_id(fragment_mol, canonicalization='openeye')
 
-    if mol_provenance:
-        provenance['routine']['enumerate_states'] = mol_provenance['routine']['enumerate_states']
+                frag = identifiers['canonical_isomeric_smiles']
+                fragments_json_dict[frag] = {'identifiers': identifiers}
+                fragments_json_dict[frag]['provenance'] = provenance
+                fragments_json_dict[frag]['provenance']['canonicalization'] = identifiers.pop('provenance')
 
-    # Generate identifiers for fragments
-    fragments_json_dict = {}
-    for fragm in fragments:
-        for i, frag in enumerate(fragments[fragm]):
-            fragment_mol = chemi.smiles_to_oemol(frag)
-            identifiers = to_molecule_id(fragment_mol, canonicalization='openeye')
+        if json_filename:
+            with open(json_filename, 'w') as f:
+                json.dump(fragments_json_dict, f, indent=2, sort_keys=True)
 
-            frag = identifiers['canonical_isomeric_smiles']
-            fragments_json_dict[frag] = {'identifiers': identifiers}
-            fragments_json_dict[frag]['provenance'] = provenance
-            fragments_json_dict[frag]['provenance']['canonicalization'] = identifiers.pop('provenance')
+        return fragments_json_dict
 
-    if json_filename:
-        with open(json_filename, 'w') as f:
-            json.dump(fragments_json_dict, f, indent=2, sort_keys=True)
+    def generate_torsiondrive_input(self, frag, json_filename=None):
+        """
+        Generate input for torsiondrive QCFractal portal
 
-    return fragments_json_dict
+        Parameters
+        ----------
+        fragment_dict: dict
+            dictionary with fragment identifiers and provenance
+        workflow_id: str
+            workflow to use for options
+        options: dict, optional, default None
+            Keyword options. If None will use options defined in workflow
+        json_filename: str, optional, default None
+            If given will write jobs to json file
 
+        Returns
+        -------
+        torsiondrive_inputs: dictionary defining the molecule and torsiondrive job options.
 
-def generate_torsiondrive_input(fragment_dict, workflow_id, options=None, json_filename=None):
-    """
-    Generate input for torsiondrive QCFractal portal
+        """
 
-    Parameters
-    ----------
-    fragment_dict: dict
-        dictionary with fragment identifiers and provenance
-    workflow_id: str
-        workflow to use for options
-    options: dict, optional, default None
-        Keyword options. If None will use options defined in workflow
-    json_filename: str, optional, default None
-        If given will write jobs to json file
+        options = self.off_workflow.get_options('torsiondrive_input')['options']
+        provenance = _get_provenance(workflow_id=self.workflow_id, routine='torsiondrive_input')
+        frag['provenance']['routine']['torsiondrive_input'] = provenance['routine']['torsiondrive_input']
+        provenance = frag['provenance']
 
-    Returns
-    -------
-    torsiondrive_inputs: dictionary defining the molecule and torsiondrive job options.
+        mol_id = frag['identifiers']
 
-    """
+        mapped_smiles = mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles']
+        mapped_mol = chemi.smiles_to_oemol(mapped_smiles)
 
-    options = _get_options(workflow_id=workflow_id, routine='torsiondrive_input')
-    provenance = _get_provenance(workflow_id=workflow_id, routine='torsiondrive_input')
-    fragment_dict['provenance']['routine']['torsiondrive_input'] = provenance['routine']['torsiondrive_input']
-    provenance = fragment_dict['provenance']
+        if options.pop('max_conf') == 1:
+            # Generate 1 conformation for all jobs
+            try:
+                qm_mol = chemi.to_mapped_QC_JSON_geometry(mapped_mol)
+            except RuntimeError:
+                utils.logger().warning("{} does not have coordinates. This can happen for several reasons related to Omega. "
+                              "{} will not be included in fragments dictionary".format(
+                        mol_id['canonical_isomeric_smiles'], mol_id['canonical_isomeric_smiles']))
 
-    mol_id = fragment_dict['identifiers']
+        identifier = mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles']
+        torsiondrive_inputs = {identifier: {'torsiondrive_input': {}, 'provenance': provenance}}
+        needed_torsion_drives = torsions.define_torsiondrive_jobs(torsions.find_torsions(mapped_mol), **options)
+        for i, job in enumerate(needed_torsion_drives):
+            torsiondrive_input = dict()
+            torsiondrive_input['initial_molecule'] = qm_mol
+            torsiondrive_input['initial_molecule']['identifiers'] = mol_id
+            torsiondrive_input['dihedrals'] = needed_torsion_drives[job]['dihedrals']
+            torsiondrive_input['grid_spacing'] = needed_torsion_drives[job]['grid_spacing']
+            torsiondrive_inputs[identifier]['torsiondrive_input']['job_{}'.format(i)] = torsiondrive_input
 
-    if not options:
-        options = _get_options(workflow_id, 'torsiondrive_input')
+        if json_filename:
+            with open(json_filename, 'w') as f:
+                json.dump(torsiondrive_inputs, f, indent=2, sort_keys=True)
 
-    mapped_smiles = mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles']
-    mapped_mol = chemi.smiles_to_oemol(mapped_smiles)
+        return torsiondrive_inputs
 
-    if options.pop('max_conf') == 1:
-        # Generate 1 conformation for all jobs
-        try:
-            qm_mol = chemi.to_mapped_QC_JSON_geometry(mapped_mol)
-        except RuntimeError:
-            utils.logger().warning("{} does not have coordinates. This can happen for several reasons related to Omega. "
-                          "{} will not be included in fragments dictionary".format(
-                    mol_id['canonical_isomeric_smiles'], mol_id['canonical_isomeric_smiles']))
+    def workflow(self, molecules_smiles, molecule_titles=None, generate_vis=False, write_json_intermediate=False,
+                 json_filename=None):
+        """
+        Convenience function to run Fragmenter workflow.
 
-    identifier = mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles']
-    torsiondrive_inputs = {identifier: {'torsiondrive_input': {}, 'provenance': provenance}}
-    needed_torsion_drives = torsions.define_torsiondrive_jobs(torsions.find_torsions(mapped_mol), **options)
-    for i, job in enumerate(needed_torsion_drives):
-        torsiondrive_input = dict()
-        torsiondrive_input['initial_molecule'] = qm_mol
-        torsiondrive_input['initial_molecule']['identifiers'] = mol_id
-        torsiondrive_input['dihedrals'] = needed_torsion_drives[job]['dihedrals']
-        torsiondrive_input['grid_spacing'] = needed_torsion_drives[job]['grid_spacing']
-        torsiondrive_inputs[identifier]['torsiondrive_input']['job_{}'.format(i)] = torsiondrive_input
+        Parameters
+        ----------
+        molecules_smiles: list of str
+            list of SMILES
+        molecule_titles: list of molecule names, optional. Default None
+            If list of molecule names is provided, the name will be added to provenance and used for intermediate filenames.
+            If not, the name will be the IUPAC name
+        generate_vis: bool, optional, default None
+            If True, will generate visualization of fragments
+        write_json_intermediate: bool, optional. Default False
+            If True will write JSON files for intermediate steps (enumerating states and fragments)
+        json_filename: str, optional, default None
+            filename to write jobs out to.
 
-    if json_filename:
-        with open(json_filename, 'w') as f:
-            json.dump(torsiondrive_inputs, f, indent=2, sort_keys=True)
+        Returns
+        -------
+        molecules: dict
+            JSON specs for torsiondrive jobs. Keys are canonical isomeric explicit hydrogen mapped SMILES of fragment.
 
-    return torsiondrive_inputs
+        """
 
+        # Check input
+        if not isinstance(molecules_smiles, list):
+            molecules_smiles = [molecules_smiles]
 
-def workflow(molecules_smiles, workflow_id, molecule_titles=None, generate_vis=False, write_json_intermediate=False,
-             json_filename=None):
-    """
-    Convenience function to run Fragmenter workflow.
+        all_frags = {}
 
-    Parameters
-    ----------
-    molecules_smiles: list of str
-        list of SMILES
-    molecule_titles: list of molecule names, optional. Default None
-        If list of molecule names is provided, the name will be added to provenance and used for intermediate filenames.
-        If not, the name will be the IUPAC name
-    generate_vis: bool, optional, default None
-        If True, will generate visualization of fragments
-    write_json_intermediate: bool, optional. Default False
-        If True will write JSON files for intermediate steps (enumerating states and fragments)
-    json_filename: str, optional, default None
-        filename to write jobs out to.
-
-    Returns
-    -------
-    molecules: dict
-        JSON specs for torsiondrive jobs. Keys are canonical isomeric explicit hydrogen mapped SMILES of fragment.
-
-    """
-
-    # Check input
-    if not isinstance(molecules_smiles, list):
-        molecules_smiles = [molecules_smiles]
-
-    all_frags = {}
-    options = _get_options(workflow_id=workflow_id, all=True)
-    for i, molecule_smile in enumerate(molecules_smiles):
-        filename = None
-        title = ''
-        if molecule_titles:
-            title = molecule_titles[i]
-        if write_json_intermediate and title:
-            filename = 'states_{}.json'.format(title)
-        if write_json_intermediate and not title:
-            filename = 'states_{}.json'.format(utils.make_python_identifier(molecule_smile)[0])
-        states = enumerate_states(molecule_smile, workflow_id=workflow_id, title=title, options=options['enumerate_states']['options'], json_filename=filename)
-        for j, state in enumerate(states['states']):
+        for i, molecule_smile in enumerate(molecules_smiles):
+            print(molecule_smile)
+            filename = None
+            title = ''
+            if molecule_titles:
+                title = molecule_titles[i]
             if write_json_intermediate and title:
-                filename = 'fragments_{}_{}.json'.format(title, j)
+                filename = 'states_{}.json'.format(title)
             if write_json_intermediate and not title:
-                filename = 'fragment_{}_{}.json'.format(utils.make_python_identifier(state)[0], j)
-            fragments = enumerate_fragments(state, title=title, workflow_id=workflow_id,
-                                            mol_provenance=states['provenance'], options=options['enumerate_fragments']['options'],
-                                            json_filename=filename, generate_vis=generate_vis)
-            all_frags.update(**fragments)
+                filename = 'states_{}.json'.format(utils.make_python_identifier(molecule_smile)[0])
+            self.states = self.enumerate_states(molecule_smile, title=title, json_filename=filename)
+            for j, state in enumerate(self.states['states']):
+                print(state)
+                if write_json_intermediate and title:
+                    filename = 'fragments_{}_{}.json'.format(title, j)
+                if write_json_intermediate and not title:
+                    filename = 'fragment_{}_{}.json'.format(utils.make_python_identifier(state)[0], j)
+                fragments = self.enumerate_fragments(state, title=title, mol_provenance=self.states['provenance'],
+                                                json_filename=filename, generate_vis=generate_vis)
+                print(fragments.keys())
+                all_frags.update(**fragments)
+        self.fragments = all_frags
 
-    all_jobs = {}
-    for frag in all_frags:
-        crank_jobs = generate_torsiondrive_input(all_frags[frag], workflow_id=workflow_id, options=options['torsiondrive_input']['options'])
-        all_jobs.update(crank_jobs)
+        all_jobs = {}
+        for frag in all_frags:
+            crank_jobs = self.generate_torsiondrive_input(all_frags[frag])
+            all_jobs.update(crank_jobs)
+        self.torsiondrive_jobs = all_jobs
 
-    if json_filename:
-        with open(json_filename, 'w') as f:
-            json.dump(all_jobs, f, indent=2, sort_keys=True)
-    return all_jobs
+        if json_filename:
+            with open(json_filename, 'w') as f:
+                json.dump(all_jobs, f, indent=2, sort_keys=True)
+        return all_jobs
+
+    def add_fragments_to_db(self):
+        for frag in self.torsiondrive_jobs:
+            self.off_workflow.add_fragment(frag, self.torsiondrive_jobs[frag]['torsiondrive_input'],
+                                           self.torsiondrive_jobs[frag]['provenance'])
 
 
 def _get_provenance(workflow_id, routine):
@@ -294,7 +302,7 @@ def _get_provenance(workflow_id, routine):
         dictionary with provenance and routine keywords.
 
     """
-    # ToDo Figure out what to do about routine specific provenances (parent molecules)
+
     provenance = {'creator': fragmenter.__package__,
                   'job_id': str(uuid.uuid4()),
                   'hostname': socket.gethostname(),
@@ -307,20 +315,20 @@ def _get_provenance(workflow_id, routine):
     return provenance
 
 
-def _get_options(workflow_id, routine=None, all=False):
-
-    fn = resource_filename('fragmenter', os.path.join('data', 'workflows.json'))
-    f = open(fn)
-    options = json.load(f)[workflow_id]
-    f.close()
-    if routine:
-        options = options['fragmenter'][routine]['options']
-    elif all:
-        options = options['fragmenter']
-    else:
-        raise RuntimeError("You must define a routine or set all to True for options for all fragmenter routines. ")
-
-    return options
+# def _get_options(workflow_id, routine=None, all=False):
+#
+#     fn = resource_filename('fragmenter', os.path.join('data', 'workflows.json'))
+#     f = open(fn)
+#     options = json.load(f)[workflow_id]
+#     f.close()
+#     if routine:
+#         options = options['fragmenter'][routine]['options']
+#     elif all:
+#         options = options['fragmenter']
+#     else:
+#         raise RuntimeError("You must define a routine or set all to True for options for all fragmenter routines. ")
+#
+#     return options
 
 
 def combine_json_fragments(json_inputs, json_output=None):
@@ -353,20 +361,12 @@ def combine_json_fragments(json_inputs, json_output=None):
     return fragments
 
 
-def register_workflow():
-    pass
-
-def pull_workflow():
-    pass
-
-
 def _check_workflow(workflow_json, off_workflow):
 
     for key in workflow_json:
-        print(key)
-        print(workflow_json[key])
-        print(off_workflow.get_options(key))
         if workflow_json[key] != off_workflow.get_options(key):
             raise ValueError("The workflow ID provided already exists in the database. The options for {} are different"
                              "in the registered workflow and provided workflow. The options provided are {} and "
                              "the options in the database are {}".format(key, workflow_json[key], off_workflow.get_options(key), key))
+        else:
+            return True

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -279,7 +279,7 @@ class WorkFlow(object):
         if json_filename:
             with open(json_filename, 'w') as f:
                 json.dump(all_jobs, f, indent=2, sort_keys=True)
-        return all_jobs
+        #return all_jobs
 
     def add_fragments_to_db(self):
         for frag in self.torsiondrive_jobs:

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -8,6 +8,43 @@ import fragmenter
 from fragmenter import fragment, torsions, utils, chemi
 from openeye import oechem
 from cmiles import to_molecule_id
+import qcportal as portal
+
+
+class WorkFlow(object):
+
+    def __init__(self, workflow_id, client, workflow_json=None):
+        """
+
+        Parameters
+        ----------
+        id
+        client
+
+        Returns
+        -------
+
+        """
+        self.workflow_id = workflow_id
+
+        if workflow_json is not None:
+            with open(workflow_json) as file:
+                workflow_json = json.load(file)[workflow_id]
+        # Check that all fields exist
+
+        # Check if id already in database
+        try:
+            off_workflow = portal.collections.OpenFFWorkflow.from_server(client, workflow_id)
+            if workflow_json is not None:
+                # Check if workflows are the same
+                _check_workflow(workflow_json, off_workflow)
+                utils.logger().warning("The workflow ID provided already exits in the database. The options you "
+                                       "provided are the same as in the database. The database options will be used.")
+        except KeyError:
+            # Get workflow from json file and register
+            off_workflow = portal.collections.OpenFFWorkflow(workflow_id, options=workflow_json, client=client)
+
+        self.off_workflow = off_workflow
 
 
 def enumerate_states(molecule, workflow_id, options=None, title='', json_filename=None):
@@ -316,3 +353,20 @@ def combine_json_fragments(json_inputs, json_output=None):
     return fragments
 
 
+def register_workflow():
+    pass
+
+def pull_workflow():
+    pass
+
+
+def _check_workflow(workflow_json, off_workflow):
+
+    for key in workflow_json:
+        print(key)
+        print(workflow_json[key])
+        print(off_workflow.get_options(key))
+        if workflow_json[key] != off_workflow.get_options(key):
+            raise ValueError("The workflow ID provided already exists in the database. The options for {} are different"
+                             "in the registered workflow and provided workflow. The options provided are {} and "
+                             "the options in the database are {}".format(key, workflow_json[key], off_workflow.get_options(key), key))

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -5,7 +5,10 @@ import json
 import fragmenter
 from fragmenter import fragment, torsions, utils, chemi
 from cmiles import to_molecule_id, to_canonical_smiles_oe
-import qcportal as portal
+try:
+    import qcportal as portal
+except ImportError:
+    pass
 
 
 class WorkFlow(object):


### PR DESCRIPTION
## Description
This PR adds the ability to register a workflow to the database and pull options from the database if the workflow is already registered. 

It also starts addressing torsions that are not fully rotatable. 

## Todos
  - [x] Register workflow to database
  - [x] Get options for functions from registered workflow
  - [x] Find torsions that are in double bonds and rings
  - [ ] Generate input for restricted torsion scans

## Questions
- [ ] How far should restricted torsion scans go out of equilibrium? Should that cutoff be different for double bond and rings? 
 - [ ] What is the best workflow for restricted torsion scans? Should we generate the input configuration with OpenEye and then do a geometry optimization with the torsion restrained? 

## Status
- [ ] Ready to go