### PR TITLE
[WIP] Add the ability to run limited torsion scans on constrained torsions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ python setup.py install
 ```
 
 # Dependencies
-* openmoltools - https://github.com/choderalab/openmoltools
-* OpenEye
+Dependencies are in [`meta.yaml`](https://github.com/openforcefield/fragmenter/blob/master/devtools/conda-recipe/meta.yaml)
 
 ### Copyright
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - openeye-toolkits
     - rdkit
     - pyyaml
-    - qcfractal
 
 test:
   requires:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - openeye-toolkits
     - rdkit
     - pyyaml
+    - qcfractal
 
 test:
   requires:

--- a/examples/example_workflow.json
+++ b/examples/example_workflow.json
@@ -35,7 +35,7 @@
         },
         "restricted_optimization_options": {
           "maximum_rotation": 30,
-          "steps": 6
+          "interval": 5
         }
       },
       "torsiondrive_static_options": {

--- a/examples/example_workflow.json
+++ b/examples/example_workflow.json
@@ -52,7 +52,7 @@
           "program": "rdkit"
         }
       },
-      "constrained_optimization_static_options":{
+      "optimization_static_options":{
         "optimization_meta": {
           "program": "geometric",
           "coordsys": "tric"

--- a/examples/example_workflow.json
+++ b/examples/example_workflow.json
@@ -1,0 +1,70 @@
+{
+  "example": {
+    "fragmenter": {
+      "enumerate_states": {
+        "version": "v0.0.1",
+        "options": {
+          "protonation": false,
+          "tautomers": false,
+          "stereoisomers": true,
+          "max_states": 200,
+          "level": 0,
+          "reasonable": true,
+          "carbon_hybridization": true,
+          "suppress_hydrogen": true
+        }
+      },
+      "enumerate_fragments": {
+        "version": "v0.0.1",
+        "options": {
+          "strict_stereo": true,
+          "combinatorial": true,
+          "MAX_ROTORS": 3,
+          "remove_map": true
+        }
+      },
+      "torsiondrive_input": {
+        "version": "v0.0.1",
+        "restricted": true,
+        "torsiondrive_options": {
+          "max_conf": 1,
+          "terminal_torsion_resolution": 30,
+          "internal_torsion_resolution": 30,
+          "scan_internal_terminal_combination": 0,
+          "scan_dimension": 1
+        },
+        "restricted_optimization_options": {
+          "maximum_rotation": 30,
+          "steps": 6
+        }
+      },
+      "torsiondrive_static_options": {
+        "torsiondrive_meta": {},
+        "optimization_meta": {
+          "program": "geometric",
+          "coordsys": "tric"
+        },
+        "qc_meta": {
+          "driver": "gradient",
+          "method": "UFF",
+          "basis": "",
+          "options": "none",
+          "program": "rdkit"
+        }
+      },
+      "constrained_optimization_static_options":{
+        "optimization_meta": {
+          "program": "geometric",
+          "coordsys": "tric"
+        },
+        "qc_meta":{
+          "driver": "gradient",
+          "method": "UFF",
+          "basis": "",
+          "options": "none",
+          "program": "rdkit"
+        }
+      }
+    }
+  }
+}

--- a/fragmenter/chemi.py
+++ b/fragmenter/chemi.py
@@ -743,7 +743,7 @@ def mol_to_tagged_smiles(infile, outfile):
 def to_mapped_QC_JSON_geometry(mapped_mol, identifiers=None, atom_map=None, multiplicity=1):
     """
     Generate xyz coordinates for molecule in the order given by the atom_map. atom_map is a dictionary that maps the
-    tag on the SMILES to the atom idex in OEMol.
+    tag on the SMILES to the atom idex in OEMol. Coordinates will be converted from Angstrom to Bohr
     Parameters
     ----------
     molecule: OEMol with conformers
@@ -901,7 +901,7 @@ def from_mapped_xyz_to_mol_idx_order(mapped_coords, atom_map):
     """
     """
     # reshape
-    mapped_coords = np.array(mapped_coords, dtype=float).reshape(int(len(mapped_coords)/3), 3) * BOHR_2_ANGSTROM
+    mapped_coords = np.array(mapped_coords, dtype=float).reshape(int(len(mapped_coords)/3), 3)
     coords = np.zeros((mapped_coords.shape))
     for m in atom_map:
         coords[atom_map[m]] = mapped_coords[m-1]

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -50,7 +50,7 @@ def find_torsions(molecule, restricted=True, terminal=True):
     needed_torsion_scans = {'internal': {}, 'terminal': {}, 'restricted': {}}
     mol = oechem.OEMol(molecule)
     if restricted:
-        smarts = '[*]~[C,c]=[C,c]~[*]' # This should capture double bonds (not capturing rings because OpenEye does not
+        smarts = '[*]~[C,c]=,@[C,c]~[*]' # This should capture double bonds (not capturing rings because OpenEye does not
                                        # generate skewed conformations. ToDo: use scan in geometric or something else to get this done.
         restricted_tors = _find_torsions_from_smarts(molecule=mol, smarts=smarts)
         if len(restricted_tors) > 0:
@@ -368,13 +368,13 @@ def generate_constraint_opt_input(qc_molecule, dihedrals, maximum_rotation=30, i
             newconf = mol.NewConf(coords_2)
             oechem.OESetTorsion(newconf, tor[0], tor[1], tor[2], tor[3], angle)
             new_angle = oechem.OEGetTorsion(newconf, tor[0], tor[1], tor[2], tor[3])
-            if new_angle == dih_angle:
-                j += 1
-                if j > 1:
-                    # One equivalent angle should be generated.
-                    logger().warning("Openeye did not generate a new conformer for torsion and angle {} {}. Will not generate"
-                                 "qcfractal optimizaiton input".format(dih_idx, angle))
-                    break
+            # if new_angle == dih_angle:
+            #     j += 1
+            #     if j > 1:
+            #         # One equivalent angle should be generated.
+            #         logger().warning("Openeye did not generate a new conformer for torsion and angle {} {}. Will not generate"
+            #                      "qcfractal optimizaiton input".format(dih_idx, angle))
+            #         break
             if filename:
                 pdb = oechem.oemolostream("{}_{}.pdb".format(filename, i))
                 oechem.OEWritePDBFile(pdb, newconf)

--- a/fragmenter/utils.py
+++ b/fragmenter/utils.py
@@ -4,6 +4,15 @@ import re
 import codecs
 import copy
 
+"""
+~~~~~~~~~~~~~~~~~~~
+Conversion factors
+~~~~~~~~~~~~~~~~~~~
+"""
+BOHR_2_ANGSTROM = 0.529177210
+ANGSROM_2_BOHR = 1. / BOHR_2_ANGSTROM
+
+
 def logger(name='fragmenter', pattern='%(asctime)s %(levelname)s %(name)s: %(message)s',
            date_format='%H:%M:%S', handler=logging.StreamHandler(sys.stdout)):
     """

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -5,12 +5,12 @@ import json
 import fragmenter
 from fragmenter import fragment, torsions, utils, chemi
 from cmiles import to_molecule_id, to_canonical_smiles_oe
-#import qcportal as portal
-try:
-    import qcportal as portal
-except ImportError:
-    pass
-
+# import qcportal as portal
+# try:
+#     import qcportal as portal
+# except ImportError:
+#     pass
+import qcfractal.interface as portal
 
 class WorkFlow(object):
 
@@ -43,7 +43,7 @@ class WorkFlow(object):
                                        "provided are the same as in the database. The database options will be used.")
         except KeyError:
             # Get workflow from json file and register
-            off_workflow = portal.collections.OpenFFWorkflow(workflow_id, client=client, options=workflow_json)
+            off_workflow = portal.collections.OpenFFWorkflow(workflow_id, client, **workflow_json)
 
         self.off_workflow = off_workflow
         self.states = {}
@@ -205,7 +205,7 @@ class WorkFlow(object):
         restricted = options.pop('restricted')
         needed_torsions = torsions.find_torsions(mapped_mol, restricted)
         restricted_torsions = needed_torsions.pop('restricted')
-        optimization_jobs = torsions.define_restricted_drive(qm_mol, restricted_torsions,
+        optimization_jobs = torsions.generate_constraint_opt_input(qm_mol, restricted_torsions,
                                                              **options['restricted_optimization_options'])
         torsiondrive_jobs = torsions.define_torsiondrive_jobs(needed_torsions, **options['torsiondrive_options'])
 

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -6,12 +6,13 @@ import fragmenter
 from fragmenter import fragment, torsions, utils, chemi
 from cmiles import to_molecule_id, to_canonical_smiles_oe
 import copy
-# import qcportal as portal
-# try:
-#     import qcportal as portal
-# except ImportError:
-#     pass
-import qcfractal.interface as portal
+#import qcportal as portal
+# For Travis CI
+try:
+    import qcfractal.interface as portal
+except ImportError:
+    pass
+
 
 class WorkFlow(object):
 

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -48,7 +48,7 @@ class WorkFlow(object):
         self.off_workflow = off_workflow
         self.states = {}
         self.fragments = {}
-        self.torsiondrive_jobs = {}
+        self.qcfractal_jobs = {}
 
     def enumerate_states(self, molecule, title='', json_filename=None):
         """
@@ -289,7 +289,7 @@ class WorkFlow(object):
             if not crank_jobs:
                 continue
             all_jobs.update(crank_jobs)
-        self.torsiondrive_jobs = all_jobs
+        self.qcfractal_jobs = all_jobs
 
         if json_filename:
             with open(json_filename, 'w') as f:

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -297,12 +297,18 @@ class WorkFlow(object):
         #return all_jobs
 
     def add_fragments_to_db(self):
-        for frag in self.torsiondrive_jobs:
-            if not self.torsiondrive_jobs[frag]['torsiondrive_input']:
-                # No jobs were found for this fragments
-                continue
-            self.off_workflow.add_fragment(frag, self.torsiondrive_jobs[frag]['torsiondrive_input'],
-                                           self.torsiondrive_jobs[frag]['provenance'])
+        for frag in self.qcfractal_jobs:
+            torsiondrive_input = self.qcfractal_jobs[frag]['torsiondrive_input']
+            optimization_input = self.qcfractal_jobs[frag]['optimization_input']
+            # combine both dictionaries
+            input_data = {**torsiondrive_input, **optimization_input}
+            if input_data:
+                self.off_workflow.add_fragment(frag, input_data, self.qcfractal_jobs[frag]['provenance'])
+
+    def add_fragment_from_json(self, json_filenam):
+        with open(json_filenam) as f:
+            self.qcfractal_jobs = json.load(f)
+        self.add_fragments_to_db()
 
 
 def _get_provenance(workflow_id, routine):


### PR DESCRIPTION
## Description
This PR adds the ability to drive stiff torsions such as rings and double bonds. These changes are general enough to accommodate regular geometry optimization in the future. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Find constrained torsions
  - [x] Generate input for QCFractal
  - [x] Submit different kinds of jobs to QCFractal

The JSON specs were changes as follows:
* The workflow JSON now includes `torsiondrive_static_options` and `optimization_static_options` in the meta section of the workflow and `restricted_optimization_options` was added to the `torsiondrive_input` field. An example of the workflow JSON is [here](https://github.com/openforcefield/fragmenter/blob/workflow/examples/example_workflow.json)
* The JSON for the inputs were changed to include a `type` field to specify if a torsiondrive or optimization job will be run. If it is an optimization job, a `constrained_dict` was added. 
* I also changed the name of the jobs to the dihedral it is driving instead of arbitrary names. This will make it easy to see more information at retrieval when querying the database. 

I will add the function to submit the jobs to qcfractal once I make the necessary changes there. 
## Status
- [x] Ready to go