### PR TITLE
Starts QCFractal Integration Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Dask
+dask-worker-space/

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ install:
 
 
 script:
-  - pytest -vvv --cov=fragmenter fragmenter/tests/
+  - export OE_LICENSE=`pwd`"/oe_license.txt"
+  - pytest -vs --cov=fragmenter fragmenter/tests/
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
 
 
 script:
-  - pytest -v --cov=fragmenter fragmenter/tests/
+  - pytest -vvv --cov=fragmenter fragmenter/tests/
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,23 @@ language: python
 # Run jobs on container-based infrastructure, can be overridden per job
 dist: trusty
 
+services:
+  - mongodb
+
+addons:
+  apt:
+    sources:
+    - mongodb-3.0-precise
+    packages:
+    - mongodb-org-server
+
 matrix:
   include:
     # Extra includes for OSX since python language is not available by default on OSX
     - os: osx
       language: generic
-      env: PYTHON_VER=3.5
-    - os: osx
-      language: generic
       env: PYTHON_VER=3.6
 
-    - os: linux
-      python: 3.5
-      env: PYTHON_VER=3.5
     - os: linux
       python: 3.6
       env: PYTHON_VER=3.6
@@ -38,29 +42,15 @@ before_install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == false ]; then echo "OpenEye license will not be installed in forks."; fi
 
 install:
-
-script:
-
     # Create test environment for package
-  - conda create --yes -n test python=$PYTHON_VER pip pytest pytest-cov
+  - python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/meta.yaml
   - source activate test
 
-    # Install pip only modules
-  - pip install codecov
-
-    # Add omnia, ommia-dev and conda-forge channels
-  - conda config --add channels omnia
-  - conda config --add channels omnia/label/dev
-  - conda config --add channels conda-forge
-  - conda config --add channels openeye
-
-  # Install OpenEye toolkit
-  #- conda install --yes -c openeye openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
-
     # Build and install package
-  - conda build --python=$PYTHON_VER devtools/conda-recipe
-  - conda install --yes --use-local fragmenter
+  - python setup.py develop --no-deps
 
+
+script:
   - pytest -v --cov=fragmenter fragmenter/tests/
 
 notifications:

--- a/devtools/conda-envs/meta.yaml
+++ b/devtools/conda-envs/meta.yaml
@@ -1,0 +1,46 @@
+name: test
+channels:
+  - openeye
+  - rdkit
+dependencies:
+
+    # Base Depends
+  - python
+  - setuptools
+  - openeye-toolkits
+  - rdkit
+  - pyyaml
+
+    # Testing
+  - pytest
+  - pytest-cov
+
+    # Dask testing environment
+  - dask
+  - distributed
+
+    # QCFractal depends, bad form as we are snapshotting github
+  - numpy
+  - pandas
+  - mongodb
+  - pymongo
+  - tornado
+  - requests
+  - jsonschema
+  - bcrypt
+  - cryptography
+
+    # Pip depends
+  - pip:
+    - codecov
+    - git+git://github.com/openforcefield/cmiles.git@v0.1.1#egg=cmiles
+
+      # Fractal depends
+    - git+git://github.com/MolSSI/QCFractal@v0.3.0a#egg=qcfractal
+    - git+git://github.com/MolSSI/QCEngine@v0.4.0#egg=qcengine
+    - mongoengine
+    - pydantic
+
+      # OpenFF Flows
+    - git+git://github.com/lpwgroup/torsiondrive.git@v0.9.1#egg=torsiondrive
+    - git+git://github.com/leeping/geomeTRIC@0.9.1#egg=geometric

--- a/devtools/scripts/conda_env.py
+++ b/devtools/scripts/conda_env.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+import shutil
+import subprocess as sp
+
+# Args
+parser = argparse.ArgumentParser(description='Creates a conda environment from file for a given Python version.')
+parser.add_argument('-n', '--name', type=str, nargs=1,
+                    help='The name of the created Python environment')
+parser.add_argument('-p', '--python', type=str, nargs=1,
+                    help='The version of the created Python environment')
+parser.add_argument('conda_file', nargs='*',
+                    help='The file for the created Python environment')
+
+args = parser.parse_args()
+
+with open(args.conda_file[0], "r") as handle:
+    script = handle.read()
+
+tmp_file = "tmp_env.yaml"
+script = script.replace("- python", "- python {}*".format(args.python[0]))
+
+with open(tmp_file, "w") as handle:
+    handle.write(script)
+
+if "CONDA_EXE" in os.environ:
+    conda_path = os.environ["CONDA_EXE"]
+else:
+    conda_path = shutil.which("conda")
+
+if conda_path is None:
+    raise ValueError("Could not find conda path")
+
+print("CONDA ENV NAME  {}".format(args.name[0]))
+print("PYTHON VERSION  {}".format(args.python[0]))
+print("CONDA FILE NAME {}".format(args.conda_file[0]))
+print("CONDA path      {}".format(conda_path))
+
+sp.call("{} env create -n {} -f {}".format(conda_path, args.name[0], tmp_file), shell=True)
+os.unlink(tmp_file)

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -11,7 +11,6 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     MINICONDA=Miniconda3-latest-MacOSX-x86_64.sh
 else
     MINICONDA=Miniconda3-latest-Linux-x86_64.sh
-    export PYTHON_VER=$TRAVIS_PYTHON_VERSION
 fi
 MINICONDA_HOME=$HOME/miniconda
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
@@ -26,10 +25,8 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
     
-conda config --add channels conda-forge
-    
-conda install --yes conda conda-build jinja2 anaconda-client
-conda update --quiet --yes --all
+conda config --set always_yes yes --set changeps1 no
+conda update --q conda
 
 # Restore original directory
 popd

--- a/fragmenter/chemi.py
+++ b/fragmenter/chemi.py
@@ -897,6 +897,42 @@ def from_mapped_xyz_to_mol_idx_order(mapped_coords, atom_map):
     return coords
 
 
+def _to_xyz(qcmol, filename=None, ret=True):
+    """
+    """
+    symbols = qcmol["symbols"]
+    geometry = qcmol["geometry"]
+    geometry = geometry
+    xyz = ""
+    xyz += "{}\n".format(len(symbols))
+    xyz += "{}\n".format(qcmol['identifiers']['molecular_formula'])
+    for i in range(len(symbols)):
+        xyz += "  {}      {:05.3f}   {:05.3f}   {:05.3f}\n".format(symbols[i],
+                                                                           geometry[i * 3] * BOHR_2_ANGSTROM,
+                                                                           geometry[i * 3 + 1] * BOHR_2_ANGSTROM,
+                                                                           geometry[i * 3 + 2] * BOHR_2_ANGSTROM)
+
+    if filename:
+        with open(filename, 'w') as f:
+            f.write(xyz)
+    if ret:
+        return xyz
+
+
+def qcmol_to_xyz(qc_molecules, job=None, filename=None, ret=False):
+    """
+    """
+    xyz = ""
+    for job in qc_molecules:
+        if job == job or job is None:
+            xyz += _to_xyz(qc_molecules[job], ret=True)
+    if filename:
+        with open(filename, 'w') as f:
+            f.write(xyz)
+    if ret:
+        return xyz
+
+
 """
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Functions for molecule visualization

--- a/fragmenter/chemi.py
+++ b/fragmenter/chemi.py
@@ -1116,7 +1116,7 @@ def bond_order_tag(molecule, atom_map, bond_order_array):
             bond.SetData(tag, mbo)
 
 
-def png_atoms_labeled(smiles, fname, width=600, height=400, label_scale=2.0, scale_bondwidth=True):
+def png_atoms_labeled(smiles, fname, map=True, width=600, height=400, label_scale=2.0, scale_bondwidth=True):
     """Write out png file of molecule with atoms labeled with their map index.
 
     Parameters
@@ -1133,7 +1133,10 @@ def png_atoms_labeled(smiles, fname, width=600, height=400, label_scale=2.0, sca
     oedepict.OEPrepareDepiction(mol)
 
     opts = oedepict.OE2DMolDisplayOptions(width, height, oedepict.OEScale_AutoScale)
-    opts.SetAtomPropertyFunctor(oedepict.OEDisplayAtomMapIdx())
+    if map:
+        opts.SetAtomPropertyFunctor(oedepict.OEDisplayAtomMapIdx())
+    if not map:
+        opts.SetAtomPropertyFunctor(oedepict.OEDisplayAtomIdx())
     opts.SetAtomPropLabelFont(oedepict.OEFont(oechem.OEDarkGreen))
     opts.SetAtomPropLabelFontScale(label_scale)
     opts.SetBondWidthScaling(scale_bondwidth)

--- a/fragmenter/tests/test_fractal.py
+++ b/fragmenter/tests/test_fractal.py
@@ -1,0 +1,66 @@
+""" Tests generating files for qm torsion scan """
+
+import unittest
+import json
+from fragmenter.tests.utils import get_fn, has_openeye
+import fragmenter.torsions as torsions
+from fragmenter import utils, chemi
+from cmiles import to_canonical_smiles_oe
+import warnings
+
+
+import copy
+import pytest
+import qcfractal.interface as portal
+from qcfractal import testing
+from qcfractal.testing import dask_server_fixture, recursive_dict_merge
+
+@testing.using_rdkit
+@testing.using_geometric
+@testing.using_torsiondrive
+def test_torsiondrive_run(dask_server_fixture):
+
+    # Cannot use this fixture without these services. Also cannot use `mark` and `fixture` decorators
+    pytest.importorskip("torsiondrive")
+    pytest.importorskip("geometric")
+    pytest.importorskip("rdkit")
+
+    client = portal.FractalClient(dask_server_fixture.get_address())
+
+    # Add a HOOH
+    hooh = portal.data.get_molecule("hooh.json")
+    mol_ret = client.add_molecules({"hooh": hooh})
+    default_grid_spacing = 90
+
+    # Geometric options
+    torsiondrive_options = {
+        "torsiondrive_meta": {
+            "dihedrals": [[0, 1, 2, 3]],
+            "grid_spacing": [default_grid_spacing]
+        },
+        "optimization_meta": {
+            "program": "geometric",
+            "coordsys": "tric",
+        },
+        "qc_meta": {
+            "driver": "gradient",
+            "method": "UFF",
+            "basis": "",
+            "options": "none",
+            "program": "rdkit",
+        },
+    }
+
+    instance_options = copy.deepcopy(torsiondrive_options)
+    instance_options["torsiondrive_meta"]["grid_spacing"] = [grid_spacing]
+
+    # instance_options = {**instance_options, **keyword_augments}
+    recursive_dict_merge(instance_options, keyword_augments)
+    ret = client.add_service("torsiondrive", [mol_ret["hooh"]], instance_options)
+    dask_server_fixture.await_services()
+    assert len(dask_server_fixture.list_current_tasks()) == 0
+
+
+
+
+

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -426,41 +426,6 @@ def measure_dihedral_angle(dihedral, coords):
     return degree
 
 
-def equiv_torsions(mapped_smiles, restricted=False, central_bonds=None):
-    """
-    Find all torsions of a central bond
-
-    Parameters
-    ----------
-    mapped_smiles
-    restricted
-    central_bonds
-
-    Returns
-    -------
-
-    """
-    mapped_mol = chemi.smiles_to_oemol(mapped_smiles)
-    mol = oechem.OEMol(mapped_mol)
-    terminal_smarts = '[*]~[*]-[X2H1,X3H2,X4H3]-[#1]'
-    terminal_torsions = _find_torsions_from_smarts(mol, terminal_smarts)
-    mid_torsions = [[tor.a, tor.b, tor.c, tor.d] for tor in oechem.OEGetTorsions(mapped_mol)]
-    all_torsions = terminal_torsions + mid_torsions
-    if restricted:
-        restricted_smarts = '[*]~[C,c]=,@[C,c]~[*]'
-        restricted_torsions = _find_torsions_from_smarts(mol, restricted_smarts)
-        all_torsions = all_torsions + restricted_torsions
-    tor_idx = []
-    for tor in all_torsions:
-        tor_name = (tor[0].GetMapIdx()-1, tor[1].GetMapIdx()-1, tor[2].GetMapIdx()-1, tor[3].GetMapIdx()-1)
-        tor_idx.append(tor_name)
-    if not central_bonds:
-        central_bonds = set((tor[1], tor[2]) for tor in tor_idx)
-    eq_torsions = {cb: [tor for tor in tor_idx if cb == (tor[1], tor[2]) or  cb ==(tor[2], tor[1])] for cb in
-                        central_bonds}
-    return eq_torsions
-
-
 def get_initial_crank_state(fragment):
     """
     Generate initial crank state JSON for each crank job in fragment

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -13,7 +13,7 @@ import copy
 from . import utils, chemi
 from cmiles import to_canonical_smiles_oe
 from .utils import BOHR_2_ANGSTROM, logger
-warnings.simplefilter('always')
+# warnings.simplefilter('always')
 
 
 def find_torsions(molecule, restricted=True, terminal=True):

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -426,6 +426,41 @@ def measure_dihedral_angle(dihedral, coords):
     return degree
 
 
+def equiv_torsions(mapped_smiles, restricted=False, central_bonds=None):
+    """
+    Find all torsions of a central bond
+
+    Parameters
+    ----------
+    mapped_smiles
+    restricted
+    central_bonds
+
+    Returns
+    -------
+
+    """
+    mapped_mol = chemi.smiles_to_oemol(mapped_smiles)
+    mol = oechem.OEMol(mapped_mol)
+    terminal_smarts = '[*]~[*]-[X2H1,X3H2,X4H3]-[#1]'
+    terminal_torsions = _find_torsions_from_smarts(mol, terminal_smarts)
+    mid_torsions = [[tor.a, tor.b, tor.c, tor.d] for tor in oechem.OEGetTorsions(mapped_mol)]
+    all_torsions = terminal_torsions + mid_torsions
+    if restricted:
+        restricted_smarts = '[*]~[C,c]=,@[C,c]~[*]'
+        restricted_torsions = _find_torsions_from_smarts(mol, restricted_smarts)
+        all_torsions = all_torsions + restricted_torsions
+    tor_idx = []
+    for tor in all_torsions:
+        tor_name = (tor[0].GetMapIdx()-1, tor[1].GetMapIdx()-1, tor[2].GetMapIdx()-1, tor[3].GetMapIdx()-1)
+        tor_idx.append(tor_name)
+    if not central_bonds:
+        central_bonds = set((tor[1], tor[2]) for tor in tor_idx)
+    eq_torsions = {cb: [tor for tor in tor_idx if cb == (tor[1], tor[2]) or  cb ==(tor[2], tor[1])] for cb in
+                        central_bonds}
+    return eq_torsions
+
+
 def get_initial_crank_state(fragment):
     """
     Generate initial crank state JSON for each crank job in fragment


### PR DESCRIPTION
## Description
 - Switches testing constructs over to QCF* type via conda-envs which the cookie cutter will likely migrate too as well.
 - Adds QCFractal and depends testing, explicitly pulls many QCF dependencies from `conda` rather than accidentals via pip. This will be greatly simplified once we push Fractal out to Conda-forge or similar.
 - Pulls tagged geometric/torsiondrives for testing.
 - Adds a quick torsion drive test case.

## Status
- [ ] Ready to go