### PR TITLE
[WIP] Add option to start torsiondrive with multiple conformations

### DIFF
--- a/devtools/conda-envs/meta.yaml
+++ b/devtools/conda-envs/meta.yaml
@@ -33,7 +33,7 @@ dependencies:
     # Pip depends
   - pip:
     - codecov
-    - git+git://github.com/openforcefield/cmiles.git@v0.1.2#egg=cmiles
+    - git+git://github.com/openforcefield/cmiles.git@v0.1.3#egg=cmiles
 
       # Fractal depends
     - git+git://github.com/MolSSI/QCFractal@v0.4.0a#egg=qcfractal

--- a/fragmenter/chemi.py
+++ b/fragmenter/chemi.py
@@ -14,6 +14,8 @@ import os
 import numpy as np
 import time
 import itertools
+import copy
+from math import radians
 
 """
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -167,6 +169,44 @@ def generate_conformers(molecule, max_confs=800, dense=False, strict_stereo=True
         raise(RuntimeError("omega returned error code %d" % status))
 
     return molcopy
+
+
+def generate_grid_conformers(molecule, dihedrals, intervals):
+    """
+
+    Parameters
+    ----------
+    molecule
+    dihedrals
+    intervals
+
+    Returns
+    -------
+
+    """
+    # molecule must be mapped
+    if not cmiles.utils.has_atom_map(molecule):
+        raise ValueError("Molecule must have map indices")
+
+    # Check length of dihedrals match length of intervals
+
+    conf_mol = generate_conformers(molecule, max_confs=1)
+    conf = conf_mol.GetConfs().next()
+    coords = oechem.OEFloatArray(conf.GetMaxAtomIdx()*3)
+    conf.GetCoords(coords)
+
+    torsions = [[conf_mol.GetAtom(oechem.OEHasMapIdx(i+1)) for i in dih] for dih in dihedrals]
+
+    for i, tor in enumerate(torsions):
+        copy_conf_mol = copy.deepcopy(conf_mol)
+        conf_mol.DeleteConfs()
+        for conf in copy_conf_mol.GetConfs():
+            coords = oechem.OEFloatArray(conf.GetMaxAtomIdx()*3)
+            conf.GetCoords(coords)
+            for angle in range(5, 365, intervals[i]):
+                newconf = conf_mol.NewConf(coords)
+                oechem.OESetTorsion(newconf, tor[0], tor[1], tor[2], tor[3], radians(angle))
+    return conf_mol
 
 
 def normalize_molecule(molecule, title=''):

--- a/fragmenter/chemi.py
+++ b/fragmenter/chemi.py
@@ -8,7 +8,6 @@ from rdkit import Chem
 
 import cmiles
 from .utils import logger, ANGSROM_2_BOHR, BOHR_2_ANGSTROM
-from fragmenter import chemi
 
 import os
 import numpy as np
@@ -171,7 +170,7 @@ def generate_conformers(molecule, max_confs=800, dense=False, strict_stereo=True
     return molcopy
 
 
-def generate_grid_conformers(molecule, dihedrals, intervals):
+def generate_grid_conformers(molecule, dihedrals, intervals, max_rotation=360):
     """
 
     Parameters
@@ -203,7 +202,7 @@ def generate_grid_conformers(molecule, dihedrals, intervals):
         for conf in copy_conf_mol.GetConfs():
             coords = oechem.OEFloatArray(conf.GetMaxAtomIdx()*3)
             conf.GetCoords(coords)
-            for angle in range(5, 365, intervals[i]):
+            for angle in range(5, max_rotation+5, intervals[i]):
                 newconf = conf_mol.NewConf(coords)
                 oechem.OESetTorsion(newconf, tor[0], tor[1], tor[2], tor[3], radians(angle))
     return conf_mol

--- a/fragmenter/chemi.py
+++ b/fragmenter/chemi.py
@@ -112,7 +112,7 @@ def get_charges(molecule, max_confs=800, strict_stereo=True,
     return charged_copy
 
 
-def generate_conformers(molecule, max_confs=800, strict_stereo=True, ewindow=15.0, rms_threshold=1.0, strict_types=True,
+def generate_conformers(molecule, max_confs=800, dense=False, strict_stereo=True, ewindow=15.0, rms_threshold=1.0, strict_types=True,
                         can_order=True, copy=True):
     """Generate conformations for the supplied molecule
     Parameters
@@ -139,6 +139,10 @@ def generate_conformers(molecule, max_confs=800, strict_stereo=True, ewindow=15.
         molcopy = oechem.OEMol(molecule)
     else:
         molcopy = molecule
+
+    if dense:
+        omega_opts = oeomega.OEOmegaOptions(oeomega.OEOmegaSampling_Dense)
+        omega = oeomega.OEOmega(omega_opts)
     omega = oeomega.OEOmega()
 
     # These parameters were chosen to match http://docs.eyesopen.com/toolkits/cookbook/python/modeling/am1-bcc.html

--- a/fragmenter/chemi.py
+++ b/fragmenter/chemi.py
@@ -1,7 +1,7 @@
 """functions to manipulate, read and write OpenEye and Psi4 molecules"""
 
 try:
-    from openeye import oechem, oeomega, oeiupac, oedepict, oequacpac
+    from openeye import oechem, oeomega, oeiupac, oedepict, oequacpac, oeszybki
 except ImportError:
     raise Warning("Need license for OpenEye!")
 from rdkit import Chem
@@ -218,6 +218,82 @@ def generate_grid_conformers(molecule, dihedrals, intervals, max_rotation=360, c
 
     restore_map(conf_mol)
     return conf_mol
+
+
+def resolve_clashes(mol):
+    """
+    Taken from quanformer (https://github.com/MobleyLab/quanformer/blob/master/quanformer/initialize_confs.py#L54
+    Minimize conformers with severe steric interaction.
+    Parameters
+    ----------
+    mol : single OEChem molecule (single conformer)
+    clashfile : string
+        name of file to write output
+    Returns
+    -------
+    boolean
+        True if completed successfully, False otherwise.
+    """
+
+    # set general energy options along with the single-point specification
+    spSzybki = oeszybki.OESzybkiOptions()
+    spSzybki.SetForceFieldType(oeszybki.OEForceFieldType_MMFF94S)
+    spSzybki.SetSolventModel(oeszybki.OESolventModel_Sheffield)
+    spSzybki.SetRunType(oeszybki.OERunType_SinglePoint)
+
+    # generate the szybki MMFF94 engine for single points
+    szSP = oeszybki.OESzybki(spSzybki)
+
+    # construct minimiz options from single-points options to get general optns
+    optSzybki = oeszybki.OESzybkiOptions(spSzybki)
+
+    # now reset the option for minimization
+    optSzybki.SetRunType(oeszybki.OERunType_CartesiansOpt)
+
+    # generate szybki MMFF94 engine for minimization
+    szOpt = oeszybki.OESzybki(optSzybki)
+    # add strong harmonic restraints to nonHs
+
+    szOpt.SetHarmonicConstraints(10.0)
+    # construct a results object to contain the results of a szybki calculation
+
+    szResults = oeszybki.OESzybkiResults()
+    # work on a copy of the molecule
+    tmpmol = oechem.OEMol(mol)
+    if not szSP(tmpmol, szResults):
+        print('szybki run failed for %s' % tmpmol.GetTitle())
+        return False
+    Etotsp = szResults.GetTotalEnergy()
+    Evdwsp = szResults.GetEnergyTerm(oeszybki.OEPotentialTerms_MMFFVdW)
+    if Evdwsp > 35:
+        if not szOpt(tmpmol, szResults):
+            print('szybki run failed for %s' % tmpmol.GetTitle())
+            return False
+        Etot = szResults.GetTotalEnergy()
+        Evdw = szResults.GetEnergyTerm(oeszybki.OEPotentialTerms_MMFFVdW)
+        # wfile = open(clashfile, 'a')
+        # wfile.write(
+        #     '%s resolved bad clash: initial vdW: %.4f ; '
+        #     'resolved EvdW: %.4f\n' % (tmpmol.GetTitle(), Evdwsp, Evdw))
+        # wfile.close()
+        mol.SetCoords(tmpmol.GetCoords())
+    oechem.OESetSDData(mol, oechem.OESDDataPair('MM Szybki Single Point Energy', "%.12f" % szResults.GetTotalEnergy()))
+    return True
+
+
+def remove_clash(multi_conformer, in_place=True):
+    # resolve clashes
+    if not in_place:
+        multi_conformer = copy.deepcopy(multi_conformer)
+    confs_to_remove = []
+    for conf in multi_conformer.GetConfs():
+        if not resolve_clashes(conf):
+            confs_to_remove.append(conf)
+    for i in confs_to_remove:
+        multi_conformer.DeleteConf(i)
+
+    if not in_place:
+        return multi_conformer
 
 
 def normalize_molecule(molecule, title=''):
@@ -857,21 +933,25 @@ def qcschema_to_xyz_format(qcschema, name=None, filename=None):
         qcschema molecule in xyz format
 
     """
+    if not isinstance(qcschema, list):
+        qcschema = [qcschema]
     xyz = ""
-    symbols = qcschema['symbols']
-    coords = qcschema['geometry']
-    coords = np.asarray(coords)*BOHR_2_ANGSTROM
-    xyz += "{}\n".format(len(symbols))
-    xyz += "{}\n".format(name)
-    for i, s in enumerate(symbols):
-        xyz += "  {}      {:05.3f}   {:05.3f}   {:05.3f}\n".format(s,
-                                                                  coords[i * 3],
-                                                                  coords[i * 3 + 1],
-                                                                  coords[i * 3 + 2])
+    for qcmol in qcschema:
+        symbols = qcmol['symbols']
+        coords = qcmol['geometry']
+        coords = np.asarray(coords)*BOHR_2_ANGSTROM
+        xyz += "{}\n".format(len(symbols))
+        xyz += "{}\n".format(name)
+        for i, s in enumerate(symbols):
+            xyz += "  {}      {:05.3f}   {:05.3f}   {:05.3f}\n".format(s,
+                                                                      coords[i * 3],
+                                                                      coords[i * 3 + 1],
+                                                                      coords[i * 3 + 2])
     if filename:
         with open(filename, 'w') as f:
-            f.write(filename)
-    return xyz
+            f.write(xyz)
+    else:
+        return xyz
 
 
 def qcschema_to_xyz_traj(final_molecule_grid, filename=None):

--- a/fragmenter/chemi.py
+++ b/fragmenter/chemi.py
@@ -143,7 +143,8 @@ def generate_conformers(molecule, max_confs=800, dense=False, strict_stereo=True
     if dense:
         omega_opts = oeomega.OEOmegaOptions(oeomega.OEOmegaSampling_Dense)
         omega = oeomega.OEOmega(omega_opts)
-    omega = oeomega.OEOmega()
+    else:
+        omega = oeomega.OEOmega()
 
     # These parameters were chosen to match http://docs.eyesopen.com/toolkits/cookbook/python/modeling/am1-bcc.html
     omega.SetMaxConfs(max_confs)

--- a/fragmenter/tests/reference/workflows.json
+++ b/fragmenter/tests/reference/workflows.json
@@ -1,10 +1,10 @@
 {
-  "workflow_1": {
+  "example": {
     "fragmenter": {
       "enumerate_states": {
-        "version": "0.0.0",
+        "version": "v0.0.1",
         "options": {
-          "protonation": true,
+          "protonation": false,
           "tautomers": false,
           "stereoisomers": true,
           "max_states": 200,
@@ -15,35 +15,58 @@
         }
       },
       "enumerate_fragments": {
-        "version": "0.0.0",
+        "version": "v0.0.1",
         "options": {
-          "strict_stereo": true,
-          "combinatorial": true,
-          "MAX_ROTORS": 2,
-          "remove_map": true
+          "combinatorial": {
+            "min_rotors": 1,
+            "max_rotors": 0,
+            "min_heavy_atoms": 4,
+            "cap": false
+          }
         }
       },
       "torsiondrive_input": {
-        "version": "0.0.0",
-        "options": {
-          "max_conf": 1,
+        "version": "v0.0.1",
+        "restricted": true,
+        "multiple_confs": 1,
+        "initial_conf_grid_resolution": 180,
+        "torsiondrive_options": {
           "terminal_torsion_resolution": 30,
           "internal_torsion_resolution": 30,
           "scan_internal_terminal_combination": 0,
-          "scan_dimension": 2
+          "scan_dimension": 1
+        },
+        "restricted_optimization_options": {
+          "maximum_rotation": 30,
+          "interval": 5
         }
       },
-      "torsiondrive_meta": {},
-      "optimization_meta": {
-        "program": "geometric",
-        "coordsys": "trict"
+      "torsiondrive_static_options": {
+        "torsiondrive_meta": {},
+        "optimization_meta": {
+          "program": "geometric",
+          "coordsys": "tric"
+        },
+        "qc_meta": {
+          "driver": "gradient",
+          "method": "UFF",
+          "basis": "",
+          "options": "none",
+          "program": "rdkit"
+        }
       },
-      "qc_meta": {
-        "driver": "gradient",
-        "method": "UFF",
-        "basis": "",
-        "options": "none",
-        "program": "rdkit"
+      "optimization_static_options":{
+        "optimization_meta": {
+          "program": "geometric",
+          "coordsys": "tric"
+        },
+        "qc_meta":{
+          "driver": "gradient",
+          "method": "UFF",
+          "basis": "",
+          "options": "none",
+          "program": "rdkit"
+        }
       }
     }
   }

--- a/fragmenter/tests/test_chemi.py
+++ b/fragmenter/tests/test_chemi.py
@@ -39,7 +39,6 @@ def test_connectivity_table(mapped_molecule):
 
 @using_openeye
 def test_to_mapped_xyz():
-    #This fails because the coordinates are different if mol has map indices.
     from openeye import oechem
     smiles = 'HC(H)(C(H)(H)OH)OH'
     mapped_smiles = '[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]'
@@ -62,6 +61,21 @@ def test_to_mapped_xyz():
     xyz_1 = sorted(xyz_1.split('\n')[2:-1])
     xyz_2 = sorted(xyz_2.split('\n')[2:-1])
     assert xyz_1 == xyz_2
+
+@using_openeye
+def teat_qcschema_to_xyz():
+    smiles = 'HC(H)(C(H)(H)OH)OH'
+    mapped_smiles = '[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]'
+    mol = cmiles.utils.load_molecule(smiles)
+    mapped_mol = cmiles.utils.load_molecule(mapped_smiles)
+
+    dihedrals = [(2, 0, 1, 3), (0, 1, 3, 9), (1, 0, 2, 8)]
+    intervals = [90, 90, 90]
+    mult_conf = chemi.generate_grid_conformers(mapped_mol, dihedrals, intervals)
+
+    # generate list of qcschema molecules
+    qcschema_molecules = [cmiles.utils.mol_to_map_ordered_qcschema(conf, mol_id) for conf in multi_conf.GetConfs()]
+
 
 @using_openeye
 def test_grid_multi_conformers():
@@ -95,3 +109,11 @@ def test_remove_atom_map():
 
     chemi.restore_map(mapped_mol)
     assert oechem.OEMolToSmiles(mapped_mol) == mapped_smiles
+
+@using_openeye
+def test_remove_clashes():
+    pass
+
+@using_openeye
+def test_resolve_clashes():
+    pass

--- a/fragmenter/tests/test_chemi.py
+++ b/fragmenter/tests/test_chemi.py
@@ -60,4 +60,25 @@ def test_to_mapped_xyz():
     xyz_2 = chemi.to_mapped_xyz(mapped_mol)
     #assert xyz_1 == xyz_2
 
+@using_openeye
+def test_grid_multi_conformers():
+    "Test generating grid multiconformer"
+    smiles = 'HC(H)(C(H)(H)OH)OH'
+    mapped_smiles = '[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]'
+    mol = cmiles.utils.load_molecule(smiles)
+    mapped_mol = cmiles.utils.load_molecule(mapped_smiles)
+
+    dihedrals = [(2, 0, 1, 3), (0, 1, 3, 9), (1, 0, 2, 8)]
+    intervals = [60, 60, 60]
+    with pytest.raises(ValueError):
+        chemi.generate_grid_conformers(mol, dihedrals, intervals)
+
+    mult_conf = chemi.generate_grid_conformers(mapped_mol, dihedrals, intervals)
+    assert mult_conf.GetMaxConfIdx() == 216
+
+    intervals = [90, 90, 90]
+    mult_conf = chemi.generate_grid_conformers(mapped_mol, dihedrals, intervals)
+    assert mult_conf.GetMaxConfIdx() == 64
+
+
 

--- a/fragmenter/tests/test_chemi.py
+++ b/fragmenter/tests/test_chemi.py
@@ -4,6 +4,8 @@ from fragmenter import chemi
 from fragmenter.tests.utils import has_openeye
 import pytest
 import numpy as np
+from .utils import using_openeye
+import cmiles
 
 @pytest.fixture
 def mapped_molecule():
@@ -35,6 +37,27 @@ def test_connectivity_table(mapped_molecule):
         # assert that bond order is the same
         assert expected_table[match][0][-1] == bond[-1]
 
+@using_openeye
+def test_to_mapped_xyz():
+    #This fails because the coordinates are different if mol has map indices.
+    from openeye import oechem
+    smiles = 'HC(H)(C(H)(H)OH)OH'
+    mapped_smiles = '[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]'
+    mol = cmiles.utils.load_molecule(smiles)
+    mapped_mol = cmiles.utils.load_molecule(mapped_smiles)
 
+    with pytest.raises(ValueError):
+        chemi.to_mapped_xyz(mapped_mol)
+    # generate conformer
+    mol = chemi.generate_conformers(mol, max_confs=1)
+    mapped_mol = chemi.generate_conformers(mapped_mol, max_confs=1)
+    atom_map = cmiles.utils.get_atom_map(mol, mapped_smiles)
+
+    with pytest.raises(ValueError):
+        chemi.to_mapped_xyz(mol)
+
+    xyz_1 = chemi.to_mapped_xyz(mol, atom_map)
+    xyz_2 = chemi.to_mapped_xyz(mapped_mol)
+    #assert xyz_1 == xyz_2
 
 

--- a/fragmenter/tests/test_chemi.py
+++ b/fragmenter/tests/test_chemi.py
@@ -58,7 +58,10 @@ def test_to_mapped_xyz():
 
     xyz_1 = chemi.to_mapped_xyz(mol, atom_map)
     xyz_2 = chemi.to_mapped_xyz(mapped_mol)
-    #assert xyz_1 == xyz_2
+
+    xyz_1 = sorted(xyz_1.split('\n')[2:-1])
+    xyz_2 = sorted(xyz_2.split('\n')[2:-1])
+    assert xyz_1 == xyz_2
 
 @using_openeye
 def test_grid_multi_conformers():
@@ -80,5 +83,15 @@ def test_grid_multi_conformers():
     mult_conf = chemi.generate_grid_conformers(mapped_mol, dihedrals, intervals)
     assert mult_conf.GetMaxConfIdx() == 64
 
+@using_openeye
+def test_remove_atom_map():
+    from openeye import oechem
+    mapped_smiles = '[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]'
+    mapped_mol = oechem.OEMol()
+    oechem.OESmilesToMol(mapped_mol, mapped_smiles)
 
+    chemi.remove_map(mapped_mol)
+    assert oechem.OEMolToSmiles(mapped_mol) == 'C(CO)O'
 
+    chemi.restore_map(mapped_mol)
+    assert oechem.OEMolToSmiles(mapped_mol) == mapped_smiles

--- a/fragmenter/tests/test_utils.py
+++ b/fragmenter/tests/test_utils.py
@@ -10,24 +10,6 @@ from cmiles.utils import mol_to_smiles
 
 class TesTorsions(unittest.TestCase):
 
-    @unittest.skipUnless(has_openeye, 'Cannot test without openeye')
-    def test_is_mapped(self):
-        """Test checking if atom map exists"""
-        smiles = 'CCCC'
-        tagged_smiles = '[H:5][C:1]([H:6])([H:7])[C:2]([H:8])([H:9])[C:3]([H:10])([H:11])[C:4]([H:12])([H:13])[H:14]'
-        molecule = chemi.smiles_to_oemol(smiles)
-        tagged_molecule = chemi.smiles_to_oemol(tagged_smiles)
-
-        self.assertTrue(chemi.is_mapped(tagged_molecule))
-        self.assertFalse(chemi.is_mapped(molecule))
-
-        # Add tags
-        tagged_smiles = mol_to_smiles(molecule, isomeric=True, mapped=True, explicit_hydrogen=True)
-
-        self.assertFalse(chemi.is_mapped(molecule))
-        tagged_mol = chemi.smiles_to_oemol(tagged_smiles)
-        self.assertTrue(chemi.is_mapped(tagged_mol))
-
     def test_check_molecule(self):
         """Test check moelcule"""
         pass

--- a/fragmenter/tests/test_workflow_api.py
+++ b/fragmenter/tests/test_workflow_api.py
@@ -1,13 +1,39 @@
 """ Test launch fragmenter """
 
-import unittest
+import pytest
+import qcfractal.interface as portal
 import fragmenter
 from fragmenter import workflow_api, chemi
 from fragmenter.tests.utils import get_fn, has_crank, has_openeye
 import json
 import copy
+from qcfractal import testing
+from qcfractal.testing import fractal_compute_server
 
+@testing.using_rdkit
+@testing.using_geometric
+@testing.using_torsiondrive
+def test_workflow(fractal_compute_server):
+    """Fragmenter regression test"""
 
+    pytest.importorskip("torsiondrive")
+    pytest.importorskip("geometric")
+    pytest.importorskip("rdkit")
+
+    client = portal.FractalClient(fractal_compute_server)
+    smiles = 'CCCCC'
+    workflow_id = 'example'
+    workflow_json = get_fn('workflows.json')
+
+    workflow = workflow_api.WorkFlow(client=client, workflow_json=workflow_json, workflow_id=workflow_id)
+    workflow.workflow(molecules_smiles=smiles, molecule_titles=['pentane'])
+
+    assert len(workflow.qcfractal_jobs) == 1
+    key = list(workflow.qcfractal_jobs.keys())[0]
+    assert len(workflow.qcfractal_jobs[key]) == 3
+    assert len(workflow.qcfractal_jobs[key]['optimization_input']) == 0
+    assert len(workflow.qcfractal_jobs[key]['torsiondrive_input']) == 3
+    assert len(workflow.qcfractal_jobs[key]['torsiondrive_input']['(0, 2, 3, 1)']['initial_molecule']) == 8
 # class TestWorkflow(unittest.TestCase):
 #
 #     def test_get_provenance(self):

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -11,7 +11,7 @@ from math import radians, degrees
 import copy
 
 from . import utils, chemi
-from cmiles.utils import mol_to_smiles, has_atom_map
+from cmiles.utils import mol_to_smiles, has_atom_map, get_atom_map
 from .utils import BOHR_2_ANGSTROM, logger
 # warnings.simplefilter('always')
 
@@ -338,7 +338,9 @@ def generate_constraint_opt_input(qc_molecule, dihedrals, maximum_rotation=30, i
 
     optimization_jobs = {}
     tagged_smiles = qc_molecule['identifiers']['canonical_isomeric_explicit_hydrogen_mapped_smiles']
-    mol, atom_map = chemi.get_atom_map(tagged_smiles, generate_conformer=False)
+    mol = oechem.OEMol()
+    oechem.OESmilesToMol(mol, tagged_smiles)
+    atom_map = get_atom_map(mol, tagged_smiles)
 
     coords = chemi.from_mapped_xyz_to_mol_idx_order(qc_molecule['geometry'], atom_map)
 

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -37,7 +37,7 @@ def find_torsions(molecule, restricted=True, terminal=True):
 
     """
     # Check if molecule has map
-    is_mapped = chemi.is_mapped(molecule)
+    is_mapped = has_atom_map(molecule)
     if not is_mapped:
         utils.logger().warning('Molecule does not have atom map. A new map will be generated. You might need a new tagged SMARTS if the ordering was changed')
         tagged_smiles = mol_to_smiles(molecule, isomeric=True, mapped=True, explicit_hydrogen=True)

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -40,7 +40,7 @@ class WorkFlow(object):
 
         # Check if id already in database
         try:
-            off_workflow = client.get_collection(name=workflow_id, collection_type='OpenFFWorkflow')
+            off_workflow = client.get_collection('OpenFFWorkflow', workflow_id)
             if workflow_json is not None:
                 # Check if workflows are the same
                 _check_workflow(workflow_json, off_workflow)

--- a/fragmenter/workflow_api.py
+++ b/fragmenter/workflow_api.py
@@ -6,7 +6,7 @@ import numpy as np
 import fragmenter
 from fragmenter import fragment, torsions, utils, chemi
 from cmiles import to_molecule_id
-from cmiles.utils import mol_to_smiles
+from cmiles.utils import mol_to_smiles, mol_to_map_ordered_qcschema
 import copy
 #import qcportal as portal
 # For Travis CI
@@ -40,7 +40,7 @@ class WorkFlow(object):
 
         # Check if id already in database
         try:
-            off_workflow = client.get_collection(collection_name=workflow_id, collection_type='OpenFFWorkflow')
+            off_workflow = client.get_collection(name=workflow_id, collection_type='OpenFFWorkflow')
             if workflow_json is not None:
                 # Check if workflows are the same
                 _check_workflow(workflow_json, off_workflow)
@@ -136,7 +136,7 @@ class WorkFlow(object):
         options = self.off_workflow.get_options('enumerate_fragments')['options']
 
         parent_molecule = chemi.standardize_molecule(molecule, title)
-        parent_molecule_smiles = to_canonical_smiles_oe(parent_molecule, isomeric=True, explicit_hydrogen=False,
+        parent_molecule_smiles = mol_to_smiles(parent_molecule, isomeric=True, explicit_hydrogen=False,
                                                         mapped=False)
         provenance['routine']['enumerate_fragments']['parent_molecule_name'] = parent_molecule.GetTitle()
         provenance['routine']['enumerate_fragments']['parent_molecule'] = parent_molecule_smiles
@@ -154,9 +154,7 @@ class WorkFlow(object):
         fragments_json_dict = {}
         for fragm in fragments:
             for i, frag in enumerate(fragments[fragm]):
-                fragment_mol = chemi.smiles_to_oemol(frag)
-                identifiers = to_molecule_id(fragment_mol, canonicalization='openeye')
-
+                identifiers = to_molecule_id(frag, canonicalization='openeye')
                 frag = identifiers['canonical_isomeric_smiles']
                 fragments_json_dict[frag] = {'identifiers': identifiers}
                 fragments_json_dict[frag]['provenance'] = provenance
@@ -198,28 +196,54 @@ class WorkFlow(object):
 
         mapped_smiles = mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles']
         mapped_mol = chemi.smiles_to_oemol(mapped_smiles)
+        needed_torsions = torsions.find_torsions(mapped_mol, options['restricted'])
 
-        if options['torsiondrive_options'].pop('max_conf') == 1:
-            # Generate 1 conformation for all jobs
+        if options['multiple_confs']:
+            # Generate grid of multiple conformers
+            dihedrals = []
+            for torsion_type in needed_torsions:
+                for tor in needed_torsions[torsion_type]:
+                    dihedrals.append(needed_torsions[torsion_type][tor])
+            intervals = options['initial_conf_grid_resolution']
+            if not isinstance(intervals, list):
+                intervals = [intervals]*len(dihedrals)
             try:
-                qm_mol = chemi.to_mapped_QC_JSON_geometry(mapped_mol)
+                conformers = chemi.generate_grid_conformers(mapped_mol, dihedrals=dihedrals, intervals=intervals)
             except RuntimeError:
                 utils.logger().warning("{} does not have coordinates. This can happen for several reasons related to Omega. "
                               "{} will not be included in fragments dictionary".format(
                         mol_id['canonical_isomeric_smiles'], mol_id['canonical_isomeric_smiles']))
+                return False
+
+            chemi.resolve_clashes(conformers)
+            qcschema_molecules = [mol_to_map_ordered_qcschema(conf, mol_id) for conf in conformers.GetConfs()]
+        try:
+            conformer = chemi.generate_conformers(mapped_mol, max_confs=1)
+            # resolve clashes
+            qcschema_molecule = mol_to_map_ordered_qcschema(conformer, mol_id)
+        except RuntimeError:
+            utils.logger().warning("{} does not have coordinates. This can happen for several reasons related to Omega. "
+                              "{} will not be included in fragments dictionary".format(
+                        mol_id['canonical_isomeric_smiles'], mol_id['canonical_isomeric_smiles']))
+            return False
 
         identifier = mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles']
         torsiondrive_inputs = {identifier: {'torsiondrive_input': {}, 'provenance': provenance}}
-        restricted = options.pop('restricted')
-        needed_torsions = torsions.find_torsions(mapped_mol, restricted)
         restricted_torsions = needed_torsions.pop('restricted')
-        optimization_jobs = torsions.generate_constraint_opt_input(qm_mol, restricted_torsions,
+
+        optimization_jobs = torsions.generate_constraint_opt_input(qcschema_molecule, restricted_torsions,
                                                              **options['restricted_optimization_options'])
+        torsiondrive_inputs[identifier]['optimization_input'] = optimization_jobs
         torsiondrive_jobs = torsions.define_torsiondrive_jobs(needed_torsions, **options['torsiondrive_options'])
 
+        if options['multiple_confs']:
+            qcschema_molecule = qcschema_molecules
+
+        # Currently, all jobs are started from same initial conformation
+        # ToDo Start later job from optimized conformers from last job
         for i, job in enumerate(torsiondrive_jobs):
             torsiondrive_input = {'type': 'torsiondrive_input'}
-            torsiondrive_input['initial_molecule'] = qm_mol
+            torsiondrive_input['initial_molecule'] = qcschema_molecule
             #torsiondrive_input['initial_molecule']['identifiers'] = mol_id
             torsiondrive_input['dihedrals'] = torsiondrive_jobs[job]['dihedrals']
             torsiondrive_input['grid_spacing'] = torsiondrive_jobs[job]['grid_spacing']
@@ -230,8 +254,6 @@ class WorkFlow(object):
                 else:
                     job_name += '{}'.format(torsion)
             torsiondrive_inputs[identifier]['torsiondrive_input'][job_name] = torsiondrive_input
-
-        torsiondrive_inputs[identifier]['optimization_input'] = optimization_jobs
 
         if json_filename:
             with open(json_filename, 'w') as f:


### PR DESCRIPTION
## Description
Added the ability to start `torsiondrive` from multiple starting conformations. This can speed up optimization and allows for better sampling of minima. 
## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add dense omega sampling as conformer generation option.
  - [x] Generate an ND grid of initial conformation by driving list of torsions. This allows sampling of some terminal protons that don't get sampled even with `omega.SetSampleHydrogens(True)`
  - [x] Remove conformations that have severe steric clashes. 
  - [x] Added regression test for workflow API

## Questions
- [ ] What should be the default setting for the initial conformation grid? Since `torsiondrive` optimizes all initial conformation and uses the lowest energy of the grid point, there is a tradeoff when starting with too many initial conformations. 

## Status
- [ ] Ready to go