### PR TITLE
use Pfizer minimial fragment in WBO fragmentation

### DIFF
--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -1182,7 +1182,7 @@ class WBOFragmenter(Fragmenter):
         if 'heuristic' not in self._options:
             self._options['heuristic'] = heuristic
         atoms, bonds = self._get_torsion_quartet(bond_tuple)
-        atom_map_idx, bond_tuples = self._get_ring_and_fgroups(atoms, bonds, central_bond=bond_tuple)
+        atom_map_idx, bond_tuples = self._get_ring_and_fgroups(atoms, bonds)
 
         # bond = self.get_bond(bond_tuple=bond_tuple)
         #
@@ -1264,14 +1264,12 @@ class WBOFragmenter(Fragmenter):
 
         return atom_map_idx, bond_tuples
 
-    def _get_ring_and_fgroups(self, atoms, bonds, central_bond):
+    def _get_ring_and_fgroups(self, atoms, bonds):
         """
         Keep ortho substituents
         Parameters
         ----------
-        atoms : set ints atom indices
-        bonds: set of bond tuples
-        central_bond: bond tuple
+        torions_quartet : set of set of ints and set of bond tuples
 
         Returns
         -------
@@ -1295,24 +1293,24 @@ class WBOFragmenter(Fragmenter):
                 new_atoms.update(self.ring_systems[ring_idx][0])
                 new_bonds.update(self.ring_systems[ring_idx][1])
 
-        # Now check for ortho substituents to any bond bonded to central bond
+        # Now check for ortho substituents to any bond in the fragment
         for bond in bonds:
-            # Only add ortho if the bond is bonded to the central bond to avoid having meta substituents come along without first evaluating if they are needed
-            if bond[0] in central_bond or bond[1] in central_bond:
-                oe_bond = self.get_bond(bond)
-                a1 = oe_bond.GetBgn()
-                a2 = oe_bond.GetEnd()
-                if not oe_bond.IsInRing() and (a1.IsInRing() or a2.IsInRing()) and (not a1.IsHydrogen() and not a2.IsHydrogen()):
-                    if a1.IsInRing():
-                        ring_idx = a1.GetData('ringsystem')
-                    elif a2.IsInRing():
-                        ring_idx = a2.GetData('ringsystem')
-                    else:
-                        print('Only one atom should be in a ring when checking for ortho substituents')
-                    ortho = self._find_ortho_substituent(ring_idx=ring_idx, rot_bond=bond)
-                    if ortho:
-                        new_atoms.update(ortho[0])
-                        new_bonds.update(ortho[1])
+            oe_bond = self.get_bond(bond)
+            a1 = oe_bond.GetBgn()
+            a2 = oe_bond.GetEnd()
+            if not oe_bond.IsInRing() and (a1.IsInRing() or a2.IsInRing()) and (
+                    not a1.IsHydrogen() and not a2.IsHydrogen()):
+                if a1.IsInRing():
+                    ring_idx = a1.GetData('ringsystem')
+                elif a2.IsInRing():
+                    ring_idx = a2.GetData('ringsystem')
+                else:
+                    print('Only one atom should be in a ring when checking for ortho substituents')
+                ortho = self._find_ortho_substituent(ring_idx=ring_idx, rot_bond=bond)
+                print('ortho: {}'.format(ortho))
+                if ortho:
+                    new_atoms.update(ortho[0])
+                    new_bonds.update(ortho[1])
         atoms.update(new_atoms)
         bonds.update(new_bonds)
 


### PR DESCRIPTION
## Description
WBO minimal fragment was slightly different than Pfizer. The Pfizer scheme keeps all ortho groups to all bonds in the initial group of bonds in the set while the WBO scheme only kept ortho groups to the central bond and their connected bonds. After looking at the results from the benchmark, the data doesn't look compelling enough for this change. 

![image](https://user-images.githubusercontent.com/6598229/74068608-0daec380-49ca-11ea-9cc2-4a69dde6603e.png)

In this image, the X axis shows how much bigger the Pfizer fragment is (only where the Pfizer minimal fragment is bigger because of this difference). On the Y axis is the difference in their respective distance scores. Positive Y shows that the smaller, WBO fragment has a better score, negative score the larger, Pfizer minimal fragment has a better score. Too many have negative Y values to justify this change. 

## Status
- [x] Ready to go