### PR TITLE
add explicit hydrogen when mapping dihedral indices

### DIFF
--- a/devtools/conda-envs/meta.yaml
+++ b/devtools/conda-envs/meta.yaml
@@ -9,7 +9,7 @@ dependencies:
     # Base Depends
   - python
   - setuptools
-  - openeye-toolkits
+  - openeye-toolkits=2019.Apr.2
   - rdkit
   - pyyaml
   - postgresql

--- a/devtools/conda-envs/meta.yaml
+++ b/devtools/conda-envs/meta.yaml
@@ -9,7 +9,7 @@ dependencies:
     # Base Depends
   - python
   - setuptools
-  - openeye-toolkits=2019.Apr.2
+  - openeye-toolkits=2019.10.2
   - rdkit
   - pyyaml
   - postgresql

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   run:
     - python
     - setuptools
-    - openeye-toolkits
+    - openeye-toolkits=2019.Apr.2
     - rdkit
     - pyyaml
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   run:
     - python
     - setuptools
-    - openeye-toolkits=2019.Apr.2
+    - openeye-toolkits=2019.10.2
     - rdkit
     - pyyaml
 

--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -1555,6 +1555,8 @@ class WBOFragmenter(Fragmenter):
 
             # Map torsion to canonical ordered molecule
             # First canonical order the molecule
+            # Note: potential bug - add explicit hydrogen before order atoms
+            oechem.OEAddExplicitHydrogens(mol_copy)
             cmiles._cmiles_oe.canonical_order_atoms(mol_copy)
             dih = []
             for m_idx in torsion_map_idx:


### PR DESCRIPTION
## Description
Bugfix for mapping dihedral indices. 

The original atom maps are from the parent molecule. They need to be remapped to the indices in the `canonical_isomeric_explicit_hydrogen_mapped_smiles`. But sometimes some explicit hydrogens are removed when fragmenting so they need to be added back before the dihedral indices are mapped to the fragment's indices. 

## Todos
  - [x] Add explicit hydrogen to fragment before canonical reordering atoms. 
  - [ ] Add tests. 

## Status
- [ ] Ready to go