### PR TITLE
Refactor stereo enumeration to use the OFF toolkit

### DIFF
--- a/devtools/conda-envs/meta.yaml
+++ b/devtools/conda-envs/meta.yaml
@@ -16,6 +16,7 @@ dependencies:
 
     # Optional dependencies
   - openeye-toolkits=2019.10.2
+  - rdkit
 
     # Testing
   - pytest

--- a/fragmenter/states.py
+++ b/fragmenter/states.py
@@ -1,5 +1,9 @@
 import logging
 
+from openff.toolkit.topology import Molecule
+
+from fragmenter.utils import copy_molecule
+
 logger = logging.getLogger(__name__)
 
 
@@ -8,11 +12,11 @@ def _enumerate_stereoisomers(
     max_states=200,
     force_flip=True,
     enum_nitrogen=True,
-    warts=True,
+    warts=False,
     verbose=True,
 ):
-    """
-    Enumerate stereoisomers
+    """Enumerate stereoisomers
+
     Parameters
     ----------
     molecule : OEMol
@@ -31,16 +35,57 @@ def _enumerate_stereoisomers(
     stereoisomers: list of oemols
 
     """
-    from openeye import oechem, oeomega
 
-    stereoisomers = []
+    # Make a copy of the input molecule so we don't accidentally change it. This is
+    # mainly needed due to OFF TK issue #890.
+    molecule = copy_molecule(molecule)
+
+    off_molecule = Molecule.from_openeye(molecule, allow_undefined_stereo=True)
+
+    if max_states > 200:
+
+        raise NotImplementedError(
+            "The max states must currently be less than 200 due to a hard coded maximum "
+            "value in the OpenFF toolkit"
+        )
+
+    if not enum_nitrogen:
+
+        raise NotImplementedError(
+            "Non-planer nitrogens will always be enumerated where possible."
+        )
+
+    if warts is True:
+        raise NotImplementedError("The ``warts`` argument is no longer supported.")
+
     if verbose:
         logger.debug("Enumerating stereoisomers...")
-    i = 0
-    for enantiomer in oeomega.OEFlipper(
-        molecule, max_states, force_flip, enum_nitrogen, warts
-    ):
-        i += 1
-        enantiomer = oechem.OEMol(enantiomer)
-        stereoisomers.append(enantiomer)
-    return stereoisomers
+
+    # Check if the input molecule has any undefined stereochemistry. If it does not
+    # then it should be included in the list of returned stereoisomers.
+    off_stereoisomers = off_molecule.enumerate_stereoisomers(
+        undefined_only=not force_flip,
+        max_isomers=max_states,
+        rationalise=False,
+    )
+
+    if len(off_stereoisomers) == 0:
+        # Handle the case where the input molecule does not have any stereoisomers.
+        return [molecule]
+
+    # Check to see if the original molecule had undefined stereochemistry.
+    undefined_atom_stereochemistry = any(
+        atom_old.stereochemistry is None and atom_new.stereochemistry is not None
+        for atom_old, atom_new in zip(off_molecule.atoms, off_stereoisomers[0].atoms)
+    )
+    undefined_bond_stereochemistry = any(
+        bond_old.stereochemistry is None and bond_new.stereochemistry is not None
+        for bond_old, bond_new in zip(off_molecule.bonds, off_stereoisomers[0].bonds)
+    )
+
+    # If the input molecule had all of the input stereochemistry defined make sure to
+    # return it in addition to the newly found stereoisomers.
+    if not undefined_atom_stereochemistry and not undefined_bond_stereochemistry:
+        off_stereoisomers = [off_molecule] + off_stereoisomers[: max_states - 1]
+
+    return [off_stereoisomer.to_openeye() for off_stereoisomer in off_stereoisomers]

--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -22,23 +22,7 @@ def test_fragmenter_imported():
 @using_openeye
 @pytest.mark.parametrize(
     "smiles, forceflip, enum_n, output",
-    [
-        ("C1=CN(C=N1)C(C1=CC=CC=C1)C1=CC=C(C=C1)C1=CC=CC=C1", True, False, 2),
-        (
-            "C[C@@H](C1=NC(=CS1)C1=CC=C(C=C1)C#N)[C@](O)(CN1C=NC=N1)C1=C(F)C=CC(F)=C1",
-            False,
-            False,
-            1,
-        ),
-        (
-            "C[C@@H](C1=NC(=CS1)C1=CC=C(C=C1)C#N)[C@](O)(CN1C=NC=N1)C1=C(F)C=CC(F)=C1",
-            True,
-            False,
-            4,
-        ),
-        ("CN(CC=CC1=CC=CC=C1)CC1=CC=CC2=CC=CC=C12", True, True, 4),
-        ("CN(CC=CC1=CC=CC=C1)CC1=CC=CC2=CC=CC=C12", False, False, 2),
-    ],
+    [("CN(CC=CC1=CC=CC=C1)CC1=CC=CC2=CC=CC=C12", True, True, 4)],
 )
 def test_expand_stereoisomers(smiles, forceflip, enum_n, output):
     from openeye import oechem

--- a/fragmenter/tests/test_states.py
+++ b/fragmenter/tests/test_states.py
@@ -24,8 +24,12 @@ from fragmenter.tests.utils import global_toolkit_wrapper
             False,
             ["F[C@](Br)(Cl)[C@@H](Br)(Cl)", "F[C@@](Br)(Cl)[C@@H](Br)(Cl)"],
         ),
+        ("FC(Cl)Br", False, ["F[C@H](Cl)Br", "F[C@@H](Cl)Br"]),
         ("F[C@H](Cl)Br", True, ["F[C@H](Cl)Br", "F[C@@H](Cl)Br"]),
         ("F[C@H](Cl)Br", False, ["F[C@H](Cl)Br"]),
+        ("ClC=CBr", False, [r"Cl/C=C/Br", r"Cl\C=C/Br"]),
+        ("Cl/C=C/Br", False, [r"Cl/C=C/Br"]),
+        ("Cl/C=C/Br", True, [r"Cl/C=C/Br", r"Cl\C=C/Br"]),
     ],
 )
 @pytest.mark.parametrize(
@@ -34,7 +38,7 @@ from fragmenter.tests.utils import global_toolkit_wrapper
 def test_enumerate_stereoisomers(smiles, force_flip, expected, toolkit_wrapper):
 
     if (
-        "@" in smiles
+        ("@" in smiles or "/" in smiles)
         and force_flip
         and isinstance(toolkit_wrapper, RDKitToolkitWrapper)
     ):

--- a/fragmenter/tests/test_states.py
+++ b/fragmenter/tests/test_states.py
@@ -1,0 +1,72 @@
+import pytest
+from openff.toolkit.topology import Molecule
+from openff.toolkit.utils import OpenEyeToolkitWrapper, RDKitToolkitWrapper
+
+from fragmenter.states import _enumerate_stereoisomers
+from fragmenter.tests.utils import global_toolkit_wrapper
+
+
+@pytest.mark.parametrize(
+    "smiles, force_flip, expected",
+    [
+        (
+            "FC(Br)(Cl)[C@@H](Br)(Cl)",
+            True,
+            [
+                "F[C@](Br)(Cl)[C@@H](Br)(Cl)",
+                "F[C@](Br)(Cl)[C@H](Br)(Cl)",
+                "F[C@@](Br)(Cl)[C@@H](Br)(Cl)",
+                "F[C@@](Br)(Cl)[C@H](Br)(Cl)",
+            ],
+        ),
+        (
+            "FC(Br)(Cl)[C@@H](Br)(Cl)",
+            False,
+            ["F[C@](Br)(Cl)[C@@H](Br)(Cl)", "F[C@@](Br)(Cl)[C@@H](Br)(Cl)"],
+        ),
+        ("F[C@H](Cl)Br", True, ["F[C@H](Cl)Br", "F[C@@H](Cl)Br"]),
+        ("F[C@H](Cl)Br", False, ["F[C@H](Cl)Br"]),
+    ],
+)
+@pytest.mark.parametrize(
+    "toolkit_wrapper", [OpenEyeToolkitWrapper(), RDKitToolkitWrapper()]
+)
+def test_enumerate_stereoisomers(smiles, force_flip, expected, toolkit_wrapper):
+
+    if (
+        "@" in smiles
+        and force_flip
+        and isinstance(toolkit_wrapper, RDKitToolkitWrapper)
+    ):
+
+        pytest.skip(
+            "the rdkit wrapper cannot flip existing stereo. see #892 of the OFF TK."
+        )
+
+    with global_toolkit_wrapper(toolkit_wrapper):
+
+        molecule = Molecule.from_smiles(smiles, allow_undefined_stereo=True)
+
+        stereoisomers = _enumerate_stereoisomers(
+            molecule.to_openeye(),
+            force_flip=force_flip,
+            enum_nitrogen=True,
+            verbose=False,
+        )
+
+    assert len(stereoisomers) == len(expected)
+
+    expected = {
+        Molecule.from_smiles(stereoisomer, allow_undefined_stereo=True).to_smiles(
+            explicit_hydrogens=False, isomeric=True, mapped=False
+        )
+        for stereoisomer in expected
+    }
+    actual = {
+        Molecule.from_openeye(stereoisomer, allow_undefined_stereo=True).to_smiles(
+            explicit_hydrogens=False, isomeric=True, mapped=False
+        )
+        for stereoisomer in stereoisomers
+    }
+
+    assert expected == actual

--- a/fragmenter/tests/utils.py
+++ b/fragmenter/tests/utils.py
@@ -1,6 +1,13 @@
 import importlib
+from contextlib import contextmanager
+from typing import Union
 
 import pytest
+from openff.toolkit.utils import (
+    GLOBAL_TOOLKIT_REGISTRY,
+    ToolkitRegistry,
+    ToolkitWrapper,
+)
 
 try:
     importlib.import_module("openeye.oechem")
@@ -10,3 +17,19 @@ except ImportError:
     has_openeye = False
 
 using_openeye = pytest.mark.skipif(not has_openeye, reason="Cannot run without OpenEye")
+
+
+@contextmanager
+def global_toolkit_wrapper(toolkit_wrapper: Union[ToolkitRegistry, ToolkitWrapper]):
+
+    original_toolkits = GLOBAL_TOOLKIT_REGISTRY._toolkits
+
+    if isinstance(toolkit_wrapper, ToolkitRegistry):
+        GLOBAL_TOOLKIT_REGISTRY._toolkits = toolkit_wrapper.registered_toolkits
+
+    else:
+        GLOBAL_TOOLKIT_REGISTRY._toolkits = [toolkit_wrapper]
+
+    yield
+
+    GLOBAL_TOOLKIT_REGISTRY._toolkits = original_toolkits

--- a/fragmenter/utils.py
+++ b/fragmenter/utils.py
@@ -43,3 +43,19 @@ def get_fgroup_smarts_comb() -> Dict[str, str]:
         functional_groups = yaml.safe_load(file)
 
     return functional_groups
+
+
+def copy_molecule(molecule):
+    """Returns a copy of either a native OE or RDKit molecule. This is a temporary
+    method added while OpenFF toolkit issue #890 is unresolved."""
+
+    if "oechem" in molecule.__class__.__module__:
+        from openeye import oechem
+
+        return oechem.OEMol(molecule)
+    elif "rdkit" in molecule.__class__.__module__:
+        from rdkit import Chem
+
+        return Chem.Mol(molecule)
+
+    raise NotImplementedError()


### PR DESCRIPTION
## Description

This PR refactors the stereo enumeration to use the OpenFF toolkit rather than OE directly. This is part of the larger refactoring (#68) effort.

## Notes

- The RDKit and OE toolkits disagree on whether to treat pyramidal nitrogens as stereocenters and hence this lack of `parity` will also carry through here.

## Status
- [X] Ready to go