### PR TITLE
Refactor torsion module to use the OFF toolkit

### DIFF
--- a/fragmenter/states.py
+++ b/fragmenter/states.py
@@ -1,8 +1,6 @@
 import logging
 
-from openff.toolkit.topology import Molecule
-
-from fragmenter.utils import copy_molecule
+from fragmenter.utils import to_off_molecule
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +34,7 @@ def _enumerate_stereoisomers(
 
     """
 
-    # Make a copy of the input molecule so we don't accidentally change it. This is
-    # mainly needed due to OFF TK issue #890.
-    molecule = copy_molecule(molecule)
-
-    off_molecule = Molecule.from_openeye(molecule, allow_undefined_stereo=True)
+    off_molecule = to_off_molecule(molecule)
 
     if max_states > 200:
 

--- a/fragmenter/tests/test_utilts.py
+++ b/fragmenter/tests/test_utilts.py
@@ -1,4 +1,9 @@
-from fragmenter.utils import get_fgroup_smarts, get_fgroup_smarts_comb
+from contextlib import nullcontext
+
+import pytest
+from openff.toolkit.topology import Molecule
+
+from fragmenter.utils import get_fgroup_smarts, get_fgroup_smarts_comb, get_map_index
 
 
 def test_get_fgroup_smarts():
@@ -25,3 +30,25 @@ def test_get_fgroup_smarts_comb():
     assert "amide_2" not in smarts
 
     assert len(smarts) == 12
+
+
+def test_get_map_index():
+
+    molecule = Molecule.from_smiles("[C:5]([H:1])([H:2])([H:3])([H:4])")
+    assert get_map_index(molecule, 0) == 5
+
+
+@pytest.mark.parametrize(
+    "raise_error, expected_raises",
+    [
+        (False, nullcontext()),
+        (True, pytest.raises(KeyError, match="is not in the atom map")),
+    ],
+)
+def test_get_map_index_error(raise_error, expected_raises):
+
+    molecule = Molecule.from_smiles("C")
+
+    with expected_raises:
+        map_index = get_map_index(molecule, 0, error_on_missing=raise_error) == 5
+        assert map_index == 0

--- a/fragmenter/torsions.py
+++ b/fragmenter/torsions.py
@@ -1,197 +1,57 @@
 import logging
+from typing import List, Tuple
 
-import numpy as np
+from fragmenter.utils import get_map_index, to_off_molecule
 
 logger = logging.getLogger(__name__)
 
 
-def _find_torsions_from_smarts(molecule, smarts):
-    """
-    Do a substrcutre search on provided SMARTS to find torsions that match the SAMRTS
+def find_torsion_around_bond(molecule, bond: Tuple[int, int]) -> List[int]:
+    """Find the torsion around a given central bond. When multiple torsions are found,
+    the torsion with the heaviest end groups (i.e. with the largest mass_0 + mass_3)
+    is returned.
 
     Parameters
     ----------
-    molecule: OEMol
-        molecule to search on
-    smarts: str
-        SMARTS pattern to search for
+    molecule
+        The molecule containing the central bond.
+    bond
+        The *map* indices of the atoms involved in the central bond.
 
     Returns
     -------
-    tors: list
-        list of torsions that match the SMARTS string
-
-    """
-    from openeye import oechem
-
-    # ToDO use MDL aromaticity model
-    qmol = oechem.OEQMol()
-    if not oechem.OEParseSmarts(qmol, smarts):
-        logger.warning("OEParseSmarts failed")
-    ss = oechem.OESubSearch(qmol)
-    tors = []
-    oechem.OEPrepareSearch(molecule, ss)
-    unique = True
-    for match in ss.Match(molecule, unique):
-        tor = []
-        for ma in match.GetAtoms():
-            tor.append(ma.target)
-        tors.append(tor)
-
-    return tors
-
-
-def one_torsion_per_rotatable_bond(torsion_list):
-    """
-    Keep only one torsion per rotatable bond
-    Parameters
-    ----------
-    torsion_list: list
-        list of torsion in molecule
-
-    Returns
-    -------
-    list of only one torsion per rotatable bonds
-
+        The map indices of the torsion -1, *not* the atom indices.
     """
 
-    central_bonds = np.zeros((len(torsion_list), 3), dtype=int)
-    for i, tor in enumerate(torsion_list):
-        central_bonds[i][0] = i
-        central_bonds[i][1] = tor[1].GetIdx()
-        central_bonds[i][2] = tor[2].GetIdx()
+    # Sort the bond indices to make matching torsions easier.
+    central_bond = sorted(bond)
 
-    grouped = central_bonds[central_bonds[:, 2].argsort()]
-    sorted_tors = [torsion_list[i] for i in grouped[:, 0]]
+    off_molecule = to_off_molecule(molecule)
 
-    # Keep only one torsion per rotatable bond
-    tors = []
-    best_tor = [
-        sorted_tors[0][0],
-        sorted_tors[0][0],
-        sorted_tors[0][0],
-        sorted_tors[0][0],
-    ]
-    best_tor_order = best_tor[0].GetAtomicNum() + best_tor[3].GetAtomicNum()
-    first_pass = True
-    for tor in sorted_tors:
-        logger.debug(
-            "Map Idxs: {} {} {} {}".format(
-                tor[0].GetMapIdx(),
-                tor[1].GetMapIdx(),
-                tor[2].GetMapIdx(),
-                tor[3].GetMapIdx(),
-            )
-        )
-        logger.debug(
-            "Atom Numbers: {} {} {} {}".format(
-                tor[0].GetAtomicNum(),
-                tor[1].GetAtomicNum(),
-                tor[2].GetAtomicNum(),
-                tor[3].GetAtomicNum(),
-            )
-        )
-        if (
-            tor[1].GetMapIdx() != best_tor[1].GetMapIdx()
-            or tor[2].GetMapIdx() != best_tor[2].GetMapIdx()
-        ):
-            # new_tor = True
-            if not first_pass:
-                logger.debug(
-                    "Adding to list: {} {} {} {}".format(
-                        best_tor[0].GetMapIdx(),
-                        best_tor[1].GetMapIdx(),
-                        best_tor[2].GetMapIdx(),
-                        best_tor[3].GetMapIdx(),
-                    )
-                )
-                tors.append(best_tor)
-            first_pass = False
-            best_tor = tor
-            best_tor_order = tor[0].GetAtomicNum() + tor[3].GetAtomicNum()
-            logger.debug(
-                "new_tor with central bond across atoms: {} {}".format(
-                    tor[1].GetMapIdx(), tor[2].GetMapIdx()
-                )
-            )
-        else:
-            logger.debug(
-                "Not a new_tor but now with end atoms: {} {}".format(
-                    tor[0].GetMapIdx(), tor[3].GetMapIdx()
-                )
-            )
-            tor_order = tor[0].GetAtomicNum() + tor[3].GetAtomicNum()
-            if tor_order > best_tor_order:
-                best_tor = tor
-                best_tor_order = tor_order
-    logger.debug(
-        "Adding to list: {} {} {} {}".format(
-            best_tor[0].GetMapIdx(),
-            best_tor[1].GetMapIdx(),
-            best_tor[2].GetMapIdx(),
-            best_tor[3].GetMapIdx(),
-        )
-    )
-    tors.append(best_tor)
+    largest_rank = -1
+    found_torsion = None
 
-    logger.debug("List of torsion to drive:")
-    for tor in tors:
-        logger.debug(
-            "Idx: {} {} {} {}".format(
-                tor[0].GetMapIdx(),
-                tor[1].GetMapIdx(),
-                tor[2].GetMapIdx(),
-                tor[3].GetMapIdx(),
-            )
-        )
-        logger.debug(
-            "Atom numbers: {} {} {} {}".format(
-                tor[0].GetAtomicNum(),
-                tor[1].GetAtomicNum(),
-                tor[2].GetAtomicNum(),
-                tor[3].GetAtomicNum(),
-            )
-        )
+    for atoms in off_molecule.propers:
 
-    return tors
+        atom_indices = tuple(atom.molecule_atom_index for atom in atoms)
 
+        try:
+            map_indices = tuple(get_map_index(off_molecule, i) for i in atom_indices)
+        except KeyError:
+            # Skip torsions involving un-mapped (i.e. cap) atoms.
+            continue
 
-def find_torsion_around_bond(molecule, bond):
-    """
-    Find the torsion around a given bond
-    Parameters
-    ----------
-    molecule : molecule with atom maps
-    bond : tuple of map idx of bond atoms
+        if sorted(map_indices[1:3]) != central_bond:
+            continue
 
-    Returns
-    -------
-    list of 4 atom map idx (-1)
+        rank = sum(off_molecule.atoms[atom_indices[i]].atomic_number for i in [0, 3])
 
-    Note:
-    This returns the map indices of the torsion -1, not the atom indices.
+        if rank <= largest_rank:
+            continue
 
-    """
-    from openeye import oechem
+        largest_rank = rank
+        found_torsion = [i - 1 for i in map_indices]
 
-    # if not has_atom_map(molecule):
-    #    raise ValueError("Molecule must have atom maps")
+    assert found_torsion is not None, "map indices should always be found."
 
-    terminal_smarts = "[*]~[*]-[X2H1,X3H2,X4H3]-[#1]"
-    terminal_torsions = _find_torsions_from_smarts(molecule, terminal_smarts)
-    mid_torsions = [
-        [tor.a, tor.b, tor.c, tor.d] for tor in oechem.OEGetTorsions(molecule)
-    ]
-    all_torsions = terminal_torsions + mid_torsions
-
-    tors = one_torsion_per_rotatable_bond(all_torsions)
-
-    tor_idx = [tuple(i.GetMapIdx() for i in tor) for tor in tors]
-    central_bonds = [(tor[1], tor[2]) for tor in tor_idx]
-    try:
-        idx = central_bonds.index(bond)
-    except ValueError:
-        idx = central_bonds.index(tuple(reversed(bond)))
-
-    torsion = [i - 1 for i in tor_idx[idx]]
-    return torsion
+    return found_torsion


### PR DESCRIPTION
## Description

This PR refactors the `torsions` module to use the OpenFF toolkit and removes the unused `_find_torsions_from_smarts` and `one_torsion_per_rotatable_bond` methods.

The code produced by the updated `find_torsion_around_bond` is not guaranteed to return the same result after the refactor. This is mainly due to bugs in the old `one_torsion_per_rotatable_bond` method which would occasionally return multiple torsions for the same rotatable bond, and from those the `find_torsion_around_bond` method was not guaranteed to select the torsion with the heaviest end groups as `one_torsion_per_rotatable_bond` intended to return.

Additionally, the `find_torsion_around_bond` method would (likely unintentionally) previously return a `ValueError` if the input `bond` was not rotatable . The current code will not raise such an error, however the original documentation never stated that this was intended behaviour anyway.

## Status
- [X] Ready to go