### PR TITLE
Add find ring systems utility

### DIFF
--- a/fragmenter/tests/test_chemi.py
+++ b/fragmenter/tests/test_chemi.py
@@ -1,8 +1,12 @@
 """Test chemi module"""
 
 import pytest
+from openff.toolkit.topology import Molecule
+from openff.toolkit.utils import OpenEyeToolkitWrapper, RDKitToolkitWrapper
 
 from fragmenter import chemi
+from fragmenter.chemi import find_ring_systems
+from fragmenter.tests.utils import global_toolkit_wrapper
 
 
 @pytest.mark.parametrize(
@@ -56,3 +60,43 @@ def test_normalize_molecule():
 
     normalized_mol = chemi.normalize_molecule(mol)
     assert normalized_mol.GetTitle() == "butane"
+
+
+@pytest.mark.parametrize(
+    "smiles",
+    [
+        "c1ccccc1",
+        "C1CC2CCC1C2",
+        "C12C3C4C1C5C2C3C45",
+        "c1ccc2ccccc2c1",
+        "c1ccc(cc1)C2CCCC2",
+        "c1ccc(cc1)C2CCC3C2CC3",
+        "c1cc2ccc3cccc4c3c2c(c1)cc4",
+        "C1CCC2(CC1)CCCCC2",
+        "c1ccc(cc1)Cc2ccccc2",
+    ],
+)
+@pytest.mark.parametrize(
+    "toolkit_wrapper", [OpenEyeToolkitWrapper(), RDKitToolkitWrapper()]
+)
+def test_find_ring_systems(smiles, toolkit_wrapper):
+
+    from openeye import oechem
+
+    molecule = Molecule.from_smiles(
+        smiles, allow_undefined_stereo=True, toolkit_registry=toolkit_wrapper
+    )
+
+    oe_molecule = molecule.to_openeye()
+    _, expected = oechem.OEDetermineRingSystems(oe_molecule)
+
+    with global_toolkit_wrapper(toolkit_wrapper):
+        ring_systems = find_ring_systems(molecule)
+
+    for i, ring_system in enumerate(expected):
+
+        if ring_system > 0:
+            assert ring_systems[i] == ring_system
+
+        else:
+            assert i not in ring_systems


### PR DESCRIPTION
## Description

This PR adds a new `find_ring_systems` to the `chemi` module which employs `networkx` to determine ring systems. This will in part replace the `WBOFragmenter._find_ring_systems` function.

## Status
- [X] Ready to go