### PR TITLE
Refactor the chemi module to use the OFF toolkit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7]
+        python-version: [3.8]
         openeye: [true]
 
     env:

--- a/devtools/conda-envs/meta.yaml
+++ b/devtools/conda-envs/meta.yaml
@@ -11,7 +11,7 @@ dependencies:
   - python
 
     # ---- openff-toolkit deps ----
-#  - openff-toolkit-base
+#  - openff-toolkit
   - numpy
   - smirnoff99frosst
   - openff-forcefields
@@ -19,6 +19,8 @@ dependencies:
   - networkx
   - mdtraj
   - xmltodict
+  - ambertools
+  - rdkit
     # ---- openff-toolkit deps ----
 
   - cmiles-base
@@ -26,7 +28,7 @@ dependencies:
   - networkx
 
     # Optional dependencies
-  - openeye-toolkits=2019.10.2
+  - openeye-toolkits
   - rdkit
 
     # Testing

--- a/fragmenter/chemi.py
+++ b/fragmenter/chemi.py
@@ -1,130 +1,18 @@
 """functions to manipulate, read and write OpenEye and Psi4 molecules"""
-import logging
+import copy
 from typing import Dict
 
 import cmiles
 import networkx
+import numpy
 from openff.toolkit.topology import Molecule
 
-logger = logging.getLogger(__name__)
+from fragmenter.utils import to_off_molecule
 
 
-def carboxylic_acid_hack(mol):
-    """
-    This is a workaround for a known bug in Openeye where carboxylic acid fails to get charged
-    Parameters
-    ----------
-    mol : oemol
+def assign_elf10_am1_bond_orders(molecule, max_confs=800):
+    """Generate ELF10 AM1 WBOs for an OpenEye OEMol molecule.
 
-    Returns
-    -------
-
-    """
-    from openeye import oechem
-
-    # Check for Carboxylic Acid patterns in the molecule
-    smarts = "(O=)[C][O,S][H]"
-    ss = oechem.OESubSearch(smarts)
-
-    oechem.OEPrepareSearch(mol, ss)
-    unique_match = True
-
-    a_match_list = []
-    for match in ss.Match(mol, unique_match):
-
-        for ma in match.GetAtoms():
-            a_match_list.append(ma.target)
-
-    # Set the Carboxylic Acid torsion to zero for each generated conformers
-    if a_match_list:
-
-        if len(a_match_list) % 4 != 0:
-            raise ValueError("The atom matching list must be multiple of 4")
-
-        for i in range(0, len(a_match_list), 4):
-
-            chunk = a_match_list[i : i + 4]
-
-            for conf in mol.GetConfs():
-                conf.SetTorsion(chunk[0], chunk[1], chunk[2], chunk[3], 0.0)
-
-
-def smiles_to_oemol(smiles, normalize=True, **kwargs):
-    """Create a OEMolBuilder from a smiles string.
-    Parameters
-    ----------
-    smiles : str
-        SMILES representation of desired molecule.
-    Returns
-    -------
-    molecule : OEMol
-        A normalized molecule with desired smiles string.
-    """
-    from openeye import oechem
-
-    molecule = oechem.OEMol()
-    if not oechem.OESmilesToMol(molecule, smiles):
-        raise ValueError("The supplied SMILES '%s' could not be parsed." % smiles)
-
-    if normalize:
-        molecule = normalize_molecule(molecule, **kwargs)
-
-    return molecule
-
-
-def normalize_molecule(molecule, name="", add_atom_map=False):
-    """Normalize a copy of the molecule by checking aromaticity, adding explicit hydrogens and renaming by IUPAC name
-    or given title
-
-    Parameters
-    ----------
-    molecule: OEMol
-        The molecule to be normalized:
-    title: str
-        Name of molecule. If the string is empty, will use IUPAC name
-
-    Returns
-    -------
-    molcopy: OEMol
-        A (copied) version of the normalized molecule
-
-    """
-    from openeye import oechem, oeiupac
-
-    molcopy = oechem.OEMol(molecule)
-
-    # Assign aromaticity.
-    oechem.OEAssignAromaticFlags(molcopy, oechem.OEAroModelOpenEye)
-
-    # Add hydrogens.
-    oechem.OEAddExplicitHydrogens(molcopy)
-
-    # Set title to IUPAC name.
-    title = name
-    if not title:
-        title = oeiupac.OECreateIUPACName(molcopy)
-    molcopy.SetTitle(title)
-
-    # Check for any missing atom names, if found reassign all of them.
-    if any([atom.GetName() == "" for atom in molcopy.GetAtoms()]):
-        oechem.OETriposAtomNames(molcopy)
-
-    # Add canonical ordered atom maps
-    if add_atom_map:
-        cmiles.utils.add_atom_map(molcopy)
-    return molcopy
-
-
-def get_charges(
-    molecule,
-    max_confs=800,
-    strict_stereo=True,
-    normalize=True,
-    keep_confs=None,
-    legacy=True,
-    **kwargs
-):
-    """Generate charges for an OpenEye OEMol molecule.
     Parameters
     ----------
     molecule : OEMol
@@ -132,179 +20,108 @@ def get_charges(
         Omega will be used to generate max_confs conformations.
     max_confs : int, optional, default=800
         Max number of conformers to generate
-    strictStereo : bool, optional, default=True
-        If False, permits smiles strings with unspecified stereochemistry.
-        See https://docs.eyesopen.com/omega/usage.html
-    normalize : bool, optional, default=True
-        If True, normalize the molecule by checking aromaticity, adding
-        explicit hydrogens, and renaming by IUPAC name.
-    keep_confs : int, optional, default=None
-        If None, apply the charges to the provided conformation and return
-        this conformation, unless no conformation is present.
-        Otherwise, return some or all of the generated
-        conformations. If -1, all generated conformations are returned.
-        Otherwise, keep_confs = N will return an OEMol with up to N
-        generated conformations.  Multiple conformations are still used to
-        *determine* the charges.
-    legacy : bool, default=True
-        If False, uses the new OpenEye charging engine.
-        See https://docs.eyesopen.com/toolkits/python/quacpactk/OEProtonFunctions/OEAssignCharges.html#
+
     Returns
     -------
-    charged_copy : OEMol
-        A molecule with OpenEye's recommended AM1BCC charge selection scheme.
-    Notes
-    -----
-    Roughly follows
-    http://docs.eyesopen.com/toolkits/cookbook/python/modeling/am1-bcc.html
+        A molecule which contains ELF10 AM1 Wiberg Bond orders.
     """
-    from openeye import oechem, oequacpac
 
-    # If there is no geometry, return at least one conformation.
-    if molecule.GetConfs() == 0:
-        keep_confs = 1
+    from openeye import oechem
 
-    if not oechem.OEChemIsLicensed():
-        raise (ImportError("Need License for OEChem!"))
-    if not oequacpac.OEQuacPacIsLicensed():
-        raise (ImportError("Need License for oequacpac!"))
+    off_molecule = to_off_molecule(oechem.OEMol(molecule))
 
-    if normalize:
-        molecule = normalize_molecule(molecule, molecule.GetTitle())
-    else:
-        molecule = oechem.OEMol(molecule)
+    # Store the atom map separately in case it gets removed by a TK.
+    atom_map = off_molecule.properties.pop("atom_map", None)
 
-    charged_copy = generate_conformers(
-        molecule, max_confs=max_confs, strict_stereo=strict_stereo, **kwargs
-    )  # Generate up to max_confs conformers
+    # Generate a set of ELF10 conformers.
+    off_molecule = generate_conformers(off_molecule, max_confs)
+    off_molecule.apply_elf_conformer_selection()
 
-    # fix issue that causes carboxylic acid to fail charging
-    carboxylic_acid_hack(charged_copy)
+    per_conformer_bond_orders = []
 
-    if not legacy:
-        # 2017.2.1 OEToolkits new charging function
-        status = oequacpac.OEAssignCharges(charged_copy, oequacpac.OEAM1BCCCharges())
-        if not status:
-            raise (RuntimeError("OEAssignCharges failed."))
-    else:
-        # AM1BCCSym recommended by Chris Bayly to KAB+JDC, Oct. 20 2014.
-        status = oequacpac.OEAssignPartialCharges(
-            charged_copy, oequacpac.OECharges_AM1BCCSym
-        )
-        if not status:
-            raise (
-                RuntimeError("OEAssignPartialCharges returned error code %d" % status)
-            )
+    for conformer in off_molecule.conformers:
 
-    # Determine conformations to return
-    if keep_confs is None:
-        # If returning original conformation
-        original = molecule.GetCoords()
-        # Delete conformers over 1
-        for k, conf in enumerate(charged_copy.GetConfs()):
-            if k > 0:
-                charged_copy.DeleteConf(conf)
-        # Copy coordinates to single conformer
-        charged_copy.SetCoords(original)
-    elif keep_confs > 0:
-        logger.debug(
-            "keep_confs was set to %s. Molecule positions will be reset." % keep_confs
+        off_molecule.assign_fractional_bond_orders(
+            "am1-wiberg", use_conformers=[conformer]
         )
 
-        # Otherwise if a number is provided, return this many confs if available
-        for k, conf in enumerate(charged_copy.GetConfs()):
-            if k > keep_confs - 1:
-                charged_copy.DeleteConf(conf)
-    elif keep_confs == -1:
-        # If we want all conformations, continue
-        pass
-    else:
-        # Not a valid option to keep_confs
-        raise (ValueError("Not a valid option to keep_confs in get_charges."))
+        per_conformer_bond_orders.append(
+            [bond.fractional_bond_order for bond in off_molecule.bonds]
+        )
 
-    return charged_copy
+    bond_orders = [*numpy.mean(per_conformer_bond_orders, axis=0)]
+
+    for bond, bond_order in zip(off_molecule.bonds, bond_orders):
+        bond.fractional_bond_order = bond_order
+
+    # Restore the atom map.
+    if atom_map is not None:
+        off_molecule.properties["atom_map"] = atom_map
+
+    # TODO: Return an OFF molecule object once the refactor is further along. Below
+    #       this line is temporary code.
+    oe_molecule = oechem.OEMol(molecule)
+
+    if atom_map is not None:
+
+        for oe_atom in oe_molecule.GetAtoms():
+            oe_atom.SetMapIdx(atom_map[oe_atom.GetIdx()])
+
+    for oe_bond in oe_molecule.GetBonds():
+
+        bond = off_molecule.get_bond_between(oe_bond.GetBgnIdx(), oe_bond.GetEndIdx())
+        oe_bond.SetData("WibergBondOrder", bond.fractional_bond_order)
+
+    return oe_molecule
 
 
 def generate_conformers(
-    molecule,
-    max_confs=800,
-    dense=False,
-    strict_stereo=True,
-    ewindow=15.0,
-    rms_threshold=1.0,
-    strict_types=True,
-    can_order=True,
-    copy=True,
-    timeout=100,
-):
-    """Generate conformations for the supplied molecule
+    molecule: Molecule, max_confs: int = 800, rms_threshold: float = 1.0
+) -> Molecule:
+    """Generate conformations for the supplied molecule.
+
     Parameters
     ----------
-    molecule : OEMol
+    molecule
         Molecule for which to generate conformers
-    max_confs : int, optional, default=800
-        Max number of conformers to generate.  If None, use default OE Value.
-    strict_stereo : bool, optional, default=True
-        If False, permits smiles strings with unspecified stereochemistry.
-    strict_types : bool, optional, default=True
-        If True, requires that Omega have exact MMFF types for atoms in molecule; otherwise, allows the closest atom
-        type of the same element to be used.
+    max_confs
+        Max number of conformers to generate.
+    rms_threshold
+        The minimum RMS value [Angstrom] at which two conformers are considered redundant
+        and one is deleted.
+
     Returns
     -------
-    molcopy : OEMol
         A multi-conformer molecule with up to max_confs conformers.
-    Notes
-    -----
-    Roughly follows
-    http://docs.eyesopen.com/toolkits/cookbook/python/modeling/am1-bcc.html
     """
-    from openeye import oechem, oeomega
 
-    if copy:
-        molcopy = oechem.OEMol(molecule)
-    else:
-        molcopy = molecule
+    from simtk import unit
 
-    if dense:
-        omega_opts = oeomega.OEOmegaOptions(oeomega.OEOmegaSampling_Dense)
-        omega = oeomega.OEOmega(omega_opts)
-    else:
-        omega = oeomega.OEOmega()
+    off_molecule = copy.deepcopy(molecule)
 
-    atom_map = False
-    if cmiles.utils.has_atom_map(molcopy):
-        atom_map = True
-        cmiles.utils.remove_atom_map(molcopy)
+    # Store the atom map separately in case it gets removed / mangled by a TK.
+    atom_map = off_molecule.properties.pop("atom_map", None)
 
-    # These parameters were chosen to match http://docs.eyesopen.com/toolkits/cookbook/python/modeling/am1-bcc.html
-    omega.SetMaxConfs(max_confs)
-    omega.SetIncludeInput(True)
-    omega.SetCanonOrder(can_order)
+    # Canonically order the atoms in the molecule before generating the conformer.
+    # This helps ensure the same conformers are generated for the same molecules
+    # independently of their atom order.
+    canonical_molecule = off_molecule.canonical_order_atoms()
 
-    omega.SetSampleHydrogens(
-        True
-    )  # Word to the wise: skipping this step can lead to significantly different charges!
-    omega.SetEnergyWindow(ewindow)
-    omega.SetRMSThreshold(
-        rms_threshold
-    )  # Word to the wise: skipping this step can lead to significantly different charges!
+    canonical_molecule.generate_conformers(
+        n_conformers=max_confs, rms_cutoff=rms_threshold * unit.angstrom
+    )
 
-    omega.SetStrictStereo(strict_stereo)
-    omega.SetStrictAtomTypes(strict_types)
+    _, canonical_map = Molecule.are_isomorphic(
+        canonical_molecule, off_molecule, return_atom_map=True
+    )
 
-    omega.SetIncludeInput(False)  # don't include input
-    omega.SetMaxSearchTime(timeout)
-    if max_confs is not None:
-        omega.SetMaxConfs(max_confs)
+    off_molecule = canonical_molecule.remap(canonical_map)
 
-    status = omega(molcopy)  # generate conformation
-    if not status:
-        raise (RuntimeError("omega returned error code %d" % status))
+    # Restore the atom map.
+    if atom_map is not None:
+        off_molecule.properties["atom_map"] = atom_map
 
-    if atom_map:
-        cmiles.utils.restore_atom_map(molcopy)
-
-    return molcopy
+    return off_molecule
 
 
 def find_ring_systems(molecule: Molecule) -> Dict[int, int]:
@@ -359,3 +176,32 @@ def find_ring_systems(molecule: Molecule) -> Dict[int, int]:
             ring_systems[atom_index] = i + 1
 
     return ring_systems
+
+
+def smiles_to_oemol(smiles, add_atom_map: bool = False):
+    """Create an OE molecule object from an input SMILES pattern.
+    Parameters
+    ----------
+    smiles : str
+        SMILES representation of desired molecule.
+    add_atom_map
+        Whether to create a canonical atom map for the molecule.
+
+    Returns
+    -------
+    molecule : OEMol
+        A normalized molecule with desired smiles string.
+    """
+
+    from openeye import oechem
+
+    off_molecule = Molecule.from_smiles(smiles, allow_undefined_stereo=True)
+    oe_molecule = off_molecule.to_openeye()
+
+    oechem.OEPerceiveChiral(oe_molecule)
+
+    # Add canonical ordered atom maps
+    if add_atom_map:
+        cmiles.utils.add_atom_map(oe_molecule)
+
+    return oe_molecule

--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -5,6 +5,7 @@ Unit and regression test for the fragmenter package.
 # Import package, test suite, and other packages as needed
 import sys
 
+import numpy
 import pytest
 from cmiles.utils import mol_to_smiles, remove_atom_map
 
@@ -225,7 +226,7 @@ def test_atom_bond_set_to_mol():
 
 def test_calculate_wbo():
     smiles = "CCCC"
-    oemol = chemi.smiles_to_oemol(smiles, name="butane")
+    oemol = chemi.smiles_to_oemol(smiles)
     f = fragmenter.fragment.WBOFragmenter(oemol)
     mol = f.calculate_wbo()
     assert not mol
@@ -247,7 +248,8 @@ def test_compare_wbo():
     f = fragmenter.fragment.WBOFragmenter(mol)
     f.calculate_wbo()
     f._get_rotor_wbo()
-    assert f._compare_wbo(fragment=mol, bond_tuple=(3, 4)) == 0.0
+
+    assert numpy.isclose(f._compare_wbo(fragment=mol, bond_tuple=(3, 4)), 0.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This PR refactors the `chemi` module to use the OpenFF toolkit for conformer generation and AM1 ELF10 WBO assignment.

While the toolkit should give very similar WBOs to the pure OE approach this may not be guaranteed in all cases - it seems that the older versions of OE will produce slightly different WBOs for the same input conformer when computing them using a newer OE version but the same input conformer.

Further, it is currently the case that the toolkit may give very different WBOs when using the AmberTools backend rather than the OE backend. This is due to differences in how each toolkit both generates conformers and then minimises those conformers prior to computing the AM1 wavefunction.

## Status
- [ ] Ready to go