### PR TITLE
Refactor valence capping to use the OFF toolkit

### DIFF
--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -579,6 +579,6 @@ def test_cap_open_valance(input, bond, output):
     f = fragmenter.fragment.PfizerFragmenter(mol)
     atoms, bonds = f._get_torsion_quartet(bond)
     atoms, bonds = f._get_ring_and_fgroups(atoms, bonds)
-    f._cap_open_valence(atoms, bonds, bond)
+    f._cap_open_valence(atoms, bonds)
     # Check that carbon bonded to N was added
     assert f.molecule.GetAtom(oechem.OEHasMapIdx(output))

--- a/fragmenter/tests/test_utilts.py
+++ b/fragmenter/tests/test_utilts.py
@@ -3,7 +3,12 @@ from contextlib import nullcontext
 import pytest
 from openff.toolkit.topology import Molecule
 
-from fragmenter.utils import get_fgroup_smarts, get_fgroup_smarts_comb, get_map_index
+from fragmenter.utils import (
+    get_atom_index,
+    get_fgroup_smarts,
+    get_fgroup_smarts_comb,
+    get_map_index,
+)
 
 
 def test_get_fgroup_smarts():
@@ -52,3 +57,9 @@ def test_get_map_index_error(raise_error, expected_raises):
     with expected_raises:
         map_index = get_map_index(molecule, 0, error_on_missing=raise_error) == 5
         assert map_index == 0
+
+
+def test_get_atom_index():
+
+    molecule = Molecule.from_smiles("[C:5]([H:1])([H:2])([H:3])([H:4])")
+    assert get_atom_index(molecule, 5) == 0

--- a/fragmenter/utils.py
+++ b/fragmenter/utils.py
@@ -88,3 +88,31 @@ def get_map_index(
         raise KeyError(f"{atom_index} is not in the atom map ({atom_map}).")
 
     return 0 if atom_map_index is None else atom_map_index
+
+
+def get_atom_index(molecule: Molecule, map_index: int) -> int:
+    """Returns the atom index of the atom in a molecule which has the specified map
+    index.
+
+    Parameters
+    ----------
+    molecule
+        The molecule containing the atom.
+    map_index
+        The map index of the atom in the molecule.
+
+    Returns
+    -------
+        The corresponding atom index
+    """
+    inverse_atom_map = {
+        j: i for i, j in molecule.properties.get("atom_map", {}).items()
+    }
+
+    atom_index = inverse_atom_map.get(map_index, None)
+
+    assert (
+        atom_index is not None
+    ), f"{map_index} does not correspond to an atom in the molecule."
+
+    return atom_index


### PR DESCRIPTION
## Description

This PR updates the valence capping code to use the OFF toolkit. As part of this PR this unused `target_bond` was dropped and a `get_atom_index` convenience method added.

## Status
- [X] Ready to go