### PR TITLE
Use the OFF toolkit to find rotatable bonds

### DIFF
--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -321,14 +321,25 @@ def test_find_ortho_substituents():
 def test_find_rotatable_bonds():
     from openeye import oechem
 
-    smiles = "[H:38][c:1]1[c:2]([c:14]([n:28][c:5]([c:8]1[C:25]([H:64])([H:65])[N:33]2[C:17]([C:19]([N:34]([C:20]([C:18]2([H:46])[H:47])([H:50])[H:51])[C:26]([H:66])([H:67])[C:22]([H:55])([H:56])[H:57])([H:48])[H:49])([H:44])[H:45])[H:42])[N:35]([H:69])[c:16]3[n:29][c:6]([c:12]([c:13]([n:31]3)[c:7]4[c:3]([c:10]5[c:9]([c:11]([c:4]4[H:41])[F:36])[n:30][c:15]([n:32]5[C:27]([H:68])([C:23]([H:58])([H:59])[H:60])[C:24]([H:61])([H:62])[H:63])[C:21]([H:52])([H:53])[H:54])[H:40])[F:37])[H:43])[H:39]"
+    smiles = (
+        "[H:38][c:1]1[c:2]([c:14]([n:28][c:5]([c:8]1[C:25]([H:64])([H:65])[N:33]2[C:17]"
+        "([C:19]([N:34]([C:20]([C:18]2([H:46])[H:47])([H:50])[H:51])[C:26]([H:66])"
+        "([H:67])[C:22]([H:55])([H:56])[H:57])([H:48])[H:49])([H:44])[H:45])[H:42])"
+        "[N:35]([H:69])[c:16]3[n:29][c:6]([c:12]([c:13]([n:31]3)[c:7]4[c:3]([c:10]5"
+        "[c:9]([c:11]([c:4]4[H:41])[F:36])[n:30][c:15]([n:32]5[C:27]([H:68])([C:23]"
+        "([H:58])([H:59])[H:60])[C:24]([H:61])([H:62])[H:63])[C:21]([H:52])([H:53])"
+        "[H:54])[H:40])[F:37])[H:43])[H:39]"
+    )
+
     mol = oechem.OEMol()
     oechem.OESmilesToMol(mol, smiles)
-    # Add map
+
     f = fragmenter.fragment.WBOFragmenter(mol)
-    rot_bonds = f._find_rotatable_bonds()
-    assert len(rot_bonds) == 7
-    expected_rot_bonds = [
+    rotatable_bonds = f._find_rotatable_bonds()
+
+    assert len(rotatable_bonds) == 7
+
+    expected_rotatable_bonds = {
         (14, 35),
         (8, 25),
         (25, 33),
@@ -336,9 +347,9 @@ def test_find_rotatable_bonds():
         (16, 35),
         (7, 13),
         (27, 32),
-    ]
-    for bond in rot_bonds:
-        assert bond in expected_rot_bonds
+    }
+
+    assert {*rotatable_bonds} == expected_rotatable_bonds
 
 
 def test_add_substituent():


### PR DESCRIPTION
## Description

This PR refactors the `_find_rotatable_bonds` function to use the OFF toolkit. Unfortunately the OFF `find_rotatable_bonds` cannot be used here as we need to include rotatable double bonds and filter for terminal bonds.

## Status
- [X] Ready to go