### PR TITLE
Install the OFF toolkit from C-F for the CI

### DIFF
--- a/devtools/conda-envs/meta.yaml
+++ b/devtools/conda-envs/meta.yaml
@@ -9,17 +9,7 @@ dependencies:
     # Core dependencies
   - python
 
-    # ---- openff-toolkit deps ----
-#  - openff-toolkit-base
-  - numpy
-  - smirnoff99frosst
-  - openff-forcefields
-  - openmm
-  - networkx
-  - mdtraj
-  - xmltodict
-    # ---- openff-toolkit deps ----
-
+  - openff-toolkit-base >=0.9.2
   - numpy
   - pydantic
   - pyyaml
@@ -35,6 +25,3 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-
-  - pip:
-      - git+git://github.com/openforcefield/openff-toolkit.git


### PR DESCRIPTION
## Description

This PR updates the test environment to install the `openff-toolkit` from C-F rather than using `pip` now a new release has been made.

## Status
- [X] Ready to go