### PR TITLE
Add argument to set the toolkit registry

### DIFF
--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -867,10 +867,10 @@ class Fragmenter(BaseModel, abc.ABC):
 
             result = self._fragment(molecule)
 
-            result.provenance["toolkits"] = {
-                toolkit.__class__.__name__: toolkit.toolkit_version
+            result.provenance["toolkits"] = [
+                (toolkit.__class__.__name__, toolkit.toolkit_version)
                 for toolkit in GLOBAL_TOOLKIT_REGISTRY.registered_toolkits
-            }
+            ]
 
         return result
 

--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -5,6 +5,11 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import networkx
 from openff.toolkit.topology import Atom, Molecule
+from openff.toolkit.utils import (
+    GLOBAL_TOOLKIT_REGISTRY,
+    ToolkitRegistry,
+    ToolkitWrapper,
+)
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
@@ -16,7 +21,12 @@ from fragmenter.chemi import (
     find_stereocenters,
 )
 from fragmenter.states import _enumerate_stereoisomers
-from fragmenter.utils import default_functional_groups, get_atom_index, get_map_index
+from fragmenter.utils import (
+    default_functional_groups,
+    get_atom_index,
+    get_map_index,
+    global_toolkit_registry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -806,8 +816,8 @@ class Fragmenter(BaseModel, abc.ABC):
         return molecule, stereo, found_functional_groups, found_ring_systems
 
     @abc.abstractmethod
-    def fragment(self, molecule: Molecule) -> FragmentationResult:
-        """Fragments a molecule according to this class' settings.
+    def _fragment(self, molecule: Molecule) -> FragmentationResult:
+        """The internal implementation of ``fragment``.
 
         Parameters
         ----------
@@ -821,6 +831,48 @@ class Fragmenter(BaseModel, abc.ABC):
         """
 
         raise NotImplementedError()
+
+    def fragment(
+        self,
+        molecule: Molecule,
+        toolkit_registry: Optional[Union[ToolkitRegistry, ToolkitWrapper]] = None,
+    ) -> FragmentationResult:
+        """Fragments a molecule according to this class' settings.
+
+        Notes
+        -----
+        * This method is currently *not* guaranteed to be thread safe as it uses and
+          modifies the OpenFF toolkits' ``GLOBAL_TOOLKIT_REGISTRY``.
+
+        Parameters
+        ----------
+        molecule
+            The molecule to fragment.
+        toolkit_registry
+            The underlying cheminformatics toolkits to use for things like conformer
+            generation, WBO computation etc. If no value is provided, the current
+            ``GLOBAL_TOOLKIT_REGISTRY`` will be used. See the OpenFF toolkit
+            documentation for more information.
+
+        Returns
+        -------
+            The results of the fragmentation including the fragments and provenance
+            about the fragmentation.
+        """
+
+        if toolkit_registry is None:
+            toolkit_registry = GLOBAL_TOOLKIT_REGISTRY
+
+        with global_toolkit_registry(toolkit_registry):
+
+            result = self._fragment(molecule)
+
+            result.provenance["toolkits"] = {
+                toolkit.__class__.__name__: toolkit.toolkit_version
+                for toolkit in GLOBAL_TOOLKIT_REGISTRY.registered_toolkits
+            }
+
+        return result
 
     def _default_provenance(self) -> Dict[str, Any]:
         """Returns a dictionary containing default provenance information."""
@@ -879,7 +931,7 @@ class WBOFragmenter(Fragmenter):
         "threshold.",
     )
 
-    def fragment(self, molecule: Molecule) -> FragmentationResult:
+    def _fragment(self, molecule: Molecule) -> FragmentationResult:
         """Fragments a molecule in such a way that the WBO of the bond that a fragment
         is being built around does not change beyond the specified threshold.
         """
@@ -1334,7 +1386,7 @@ class PfizerFragmenter(Fragmenter):
 
     scheme: Literal["Pfizer"] = "Pfizer"
 
-    def fragment(self, molecule: Molecule) -> FragmentationResult:
+    def _fragment(self, molecule: Molecule) -> FragmentationResult:
         """Fragments a molecule according to Pfizer protocol."""
 
         (

--- a/fragmenter/tests/test_chemi.py
+++ b/fragmenter/tests/test_chemi.py
@@ -21,7 +21,8 @@ from fragmenter.chemi import (
     find_stereocenters,
     smiles_to_molecule,
 )
-from fragmenter.tests.utils import global_toolkit_wrapper, using_openeye
+from fragmenter.tests.utils import using_openeye
+from fragmenter.utils import global_toolkit_registry
 
 
 def test_assign_elf10_am1_bond_orders():
@@ -35,12 +36,12 @@ def test_assign_elf10_am1_bond_orders():
 @using_openeye
 def test_assign_elf10_am1_bond_orders_simple_parity():
 
-    with global_toolkit_wrapper(OpenEyeToolkitWrapper()):
+    with global_toolkit_registry(OpenEyeToolkitWrapper()):
 
         molecule = assign_elf10_am1_bond_orders(Molecule.from_smiles("C"))
         oe_bond_orders = [bond.fractional_bond_order for bond in molecule.bonds]
 
-    with global_toolkit_wrapper(
+    with global_toolkit_registry(
         ToolkitRegistry([AmberToolsToolkitWrapper(), OpenEyeToolkitWrapper()])
     ):
         molecule = assign_elf10_am1_bond_orders(Molecule.from_smiles("C"))

--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -423,7 +423,7 @@ def test_fragmenter_provenance(toolkit_registry, expected_provenance):
     result = DummyFragmenter().fragment(Molecule.from_smiles("[He]"), toolkit_registry)
 
     assert "toolkits" in result.provenance
-    assert [*result.provenance["toolkits"]] == expected_provenance
+    assert [name for name, _ in result.provenance["toolkits"]] == expected_provenance
 
 
 def test_wbo_fragment():

--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -427,7 +427,7 @@ def test_fragmenter_provenance(toolkit_registry, expected_provenance):
 
 
 def test_wbo_fragment():
-    """ Test build fragment"""
+    """Test build fragment"""
 
     result = WBOFragmenter().fragment(Molecule.from_smiles("CCCCC"))
 

--- a/fragmenter/tests/test_fragmenter.py
+++ b/fragmenter/tests/test_fragmenter.py
@@ -7,9 +7,19 @@ import logging
 import numpy
 import pytest
 from openff.toolkit.topology import Molecule
+from openff.toolkit.utils import (
+    GLOBAL_TOOLKIT_REGISTRY,
+    RDKitToolkitWrapper,
+    ToolkitRegistry,
+)
 
 from fragmenter.chemi import assign_elf10_am1_bond_orders, smiles_to_molecule
-from fragmenter.fragment import Fragmenter, PfizerFragmenter, WBOFragmenter
+from fragmenter.fragment import (
+    FragmentationResult,
+    Fragmenter,
+    PfizerFragmenter,
+    WBOFragmenter,
+)
 from fragmenter.tests.utils import (
     key_smarts_to_map_indices,
     smarts_set_to_map_indices,
@@ -386,6 +396,34 @@ def test_prepare_molecule():
 
     assert len(ring_systems) == 1
     assert len(ring_systems[1][0]) == 5
+
+
+@pytest.mark.parametrize(
+    "toolkit_registry, expected_provenance",
+    [
+        (
+            None,
+            [
+                toolkit.__class__.__name__
+                for toolkit in GLOBAL_TOOLKIT_REGISTRY.registered_toolkits
+            ],
+        ),
+        (RDKitToolkitWrapper(), ["RDKitToolkitWrapper"]),
+        (ToolkitRegistry([RDKitToolkitWrapper]), ["RDKitToolkitWrapper"]),
+    ],
+)
+def test_fragmenter_provenance(toolkit_registry, expected_provenance):
+    class DummyFragmenter(Fragmenter):
+        def _fragment(self, molecule: Molecule) -> FragmentationResult:
+
+            return FragmentationResult(
+                parent_smiles="[He:1]", fragments=[], provenance={}
+            )
+
+    result = DummyFragmenter().fragment(Molecule.from_smiles("[He]"), toolkit_registry)
+
+    assert "toolkits" in result.provenance
+    assert [*result.provenance["toolkits"]] == expected_provenance
 
 
 def test_wbo_fragment():

--- a/fragmenter/tests/utils.py
+++ b/fragmenter/tests/utils.py
@@ -1,15 +1,9 @@
 import importlib
 from collections import defaultdict
-from contextlib import contextmanager
 from typing import Dict, Set, TypeVar, Union
 
 import pytest
 from openff.toolkit.topology import Molecule
-from openff.toolkit.utils import (
-    GLOBAL_TOOLKIT_REGISTRY,
-    ToolkitRegistry,
-    ToolkitWrapper,
-)
 
 from fragmenter.fragment import BondTuple
 from fragmenter.utils import get_map_index
@@ -24,22 +18,6 @@ except ImportError:
     has_openeye = False
 
 using_openeye = pytest.mark.skipif(not has_openeye, reason="Cannot run without OpenEye")
-
-
-@contextmanager
-def global_toolkit_wrapper(toolkit_wrapper: Union[ToolkitRegistry, ToolkitWrapper]):
-
-    original_toolkits = GLOBAL_TOOLKIT_REGISTRY._toolkits
-
-    if isinstance(toolkit_wrapper, ToolkitRegistry):
-        GLOBAL_TOOLKIT_REGISTRY._toolkits = toolkit_wrapper.registered_toolkits
-
-    else:
-        GLOBAL_TOOLKIT_REGISTRY._toolkits = [toolkit_wrapper]
-
-    yield
-
-    GLOBAL_TOOLKIT_REGISTRY._toolkits = original_toolkits
 
 
 def smarts_set_to_map_indices(


### PR DESCRIPTION
## Description

This PR adds an argument to the `fragment` method that allows the user to easily choose which toolkit registries should be used by the OpenFF toolkit during the fragmentation. Information about the used toolkits are stored in the provenance dictionary.

```
{'toolkits': [('RDKitToolkitWrapper', '2021.03.1')]}
```

## Status
- [X] Ready to go