### PR TITLE
Fix Pfizer fragmenter returning incorrect parent

### DIFF
--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -1415,7 +1415,7 @@ class PfizerFragmenter(Fragmenter):
             )
 
         return FragmentationResult(
-            parent_smiles=molecule.to_smiles(mapped=True),
+            parent_smiles=parent.to_smiles(mapped=True),
             fragments=[
                 Fragment(smiles=fragment.to_smiles(mapped=True), bond_indices=bond)
                 for bond, fragment in fragments.items()


### PR DESCRIPTION
## Description

This PR fixes a bug whereby the `PfizerFragmenter` returns the input molecule in the result object, rather than the canonically ordered parent used in the actual fragmentation.

## Status
- [X] Ready to go