### PR TITLE
Regression tests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('.'))
 
 

--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -587,7 +587,6 @@ class Fragmenter(BaseModel, abc.ABC):
         parent_rings: RingSystems,
         atoms: Set[int],
         bonds: Set[BondTuple],
-        rot_bond: BondTuple,
     ) -> AtomAndBondSet:
         """Adds the atom and bond indices of groups ortho to those already in
         a fragment, such that they are retained during fragmentation.
@@ -614,7 +613,7 @@ class Fragmenter(BaseModel, abc.ABC):
 
         # Find the sets of atoms which are located ortho to one of the bonds being
         # fragmented.
-        ortho_atoms, ortho_bonds = cls._find_ortho_substituents(parent, bonds, rot_bond)
+        ortho_atoms, ortho_bonds = cls._find_ortho_substituents(parent, bonds)
 
         atoms.update(ortho_atoms)
         bonds.update(ortho_bonds)
@@ -654,7 +653,7 @@ class Fragmenter(BaseModel, abc.ABC):
 
     @classmethod
     def _find_ortho_substituents(
-        cls, parent: Molecule, bonds: Set[BondTuple], rot_bond: BondTuple
+        cls, parent: Molecule, bonds: Set[BondTuple]
     ) -> AtomAndBondSet:
         """Find ring substituents that are ortho to one of the rotatable bonds specified
         in a list of bonds.
@@ -684,9 +683,8 @@ class Fragmenter(BaseModel, abc.ABC):
             if map_tuple[:2] not in bonds and map_tuple[:2][::-1] not in bonds:
                 continue
 
-            if map_tuple[0] in rot_bond or map_tuple[3] in rot_bond:
-                matched_atoms.update(map_tuple[::3])
-                matched_bonds.update((map_tuple[i], map_tuple[i + 1]) for i in [0, 2])
+            matched_atoms.update(map_tuple[::3])
+            matched_bonds.update((map_tuple[i], map_tuple[i + 1]) for i in [0, 2])
 
         # Ensure the matched bonds doesn't include duplicates.
         matched_bonds = {tuple(sorted(bond)) for bond in matched_bonds}

--- a/fragmenter/fragment.py
+++ b/fragmenter/fragment.py
@@ -1405,7 +1405,7 @@ class PfizerFragmenter(Fragmenter):
             atoms, bonds = self._get_torsion_quartet(parent, bond)
 
             atoms, bonds = self._get_ring_and_fgroups(
-                parent, parent_groups, parent_rings, atoms, bonds, bond
+                parent, parent_groups, parent_rings, atoms, bonds
             )
 
             atoms, bonds = self._cap_open_valence(parent, parent_groups, atoms, bonds)

--- a/fragmenter/tests/test_regression.py
+++ b/fragmenter/tests/test_regression.py
@@ -1,0 +1,81 @@
+"""
+Regression tests for the WBO and Pfizer fragmentation schemes.
+"""
+from collections import Counter
+
+import pytest
+from openff.toolkit.topology import Molecule
+
+from fragmenter.fragment import (
+    FragmentationResult,
+    Fragmenter,
+    PfizerFragmenter,
+    WBOFragmenter,
+)
+
+
+@pytest.mark.parametrize(
+    "parent, fragments",
+    [
+        pytest.param(
+            "[H:30][c:6]1[c:7]([c:8]([c:16]([c:4]([c:5]1[H:29])[C@@:3]2([C:22](=[O:23])[N:20]([C:18](=[N+:17]2[H:37])[N:19]([H:38])[H:42])[C:21]([H:39])([H:40])[H:41])[C:2]([H:27])([H:28])[C:1]([H:24])([H:25])[H:26])[H:36])[c:9]3[c:10]([c:11]([c:12]([c:13]([c:15]3[H:35])[Cl:14])[H:34])[H:33])[H:32])[H:31]",
+            (
+                "[H:14][c:1]1[c:2]([c:5]([c:10]([c:6]([c:3]1[H:16])[H:19])[c:11]2[c:7]([c:4]([c:8]([c:12]([c:9]2[H:22])[Cl:13])[H:21])[H:17])[H:20])[H:18])[H:15]",
+                "[H:17][c:1]1[c:2]([c:4]([c:6]([c:5]([c:3]1[H:19])[H:21])[C@@:9]2([C:7](=[O:16])[N:13]([C:8](=[N+:14]2[H:30])[N:15]([H:31])[H:32])[C:11]([H:25])([H:26])[H:27])[C:12]([H:28])([H:29])[C:10]([H:22])([H:23])[H:24])[H:20])[H:18]",
+            ),
+        ),
+        pytest.param(
+            "[H:30][c:6]1[c:7]([c:8]([c:16]([c:4]([c:5]1[H:29])[C@@:3]2([C:22](=[O:23])[N:20]([C:18](=[N+:17]2[H:37])[N:19]([H:38])[H:42])[C:21]([H:39])([H:40])[H:41])[C:2]([H:27])([H:28])[C:1]([H:24])([H:25])[H:26])[H:36])[c:9]3[c:10]([c:11]([c:12]([c:13]([c:15]3[H:35])[Cl:14])[H:34])[H:33])[H:32])[H:31]",
+            (
+                "[H:14][c:1]1[c:2]([c:5]([c:10]([c:6]([c:3]1[H:16])[H:19])[c:11]2[c:7]([c:4]([c:8]([c:12]([c:9]2[H:22])[Cl:13])[H:21])[H:17])[H:20])[H:18])[H:15]",
+                "[H:17][c:1]1[c:2]([c:4]([c:6]([c:5]([c:3]1[H:19])[H:21])[C@@:9]2([C:7](=[O:16])[N:13]([C:8](=[N+:14]2[H:30])[N:15]([H:31])[H:32])[C:11]([H:25])([H:26])[H:27])[C:12]([H:28])([H:29])[C:10]([H:22])([H:23])[H:24])[H:20])[H:18]",
+            ),
+        ),
+        pytest.param(
+            "[H:30][c:6]1[c:7]([c:8]([c:16]([c:4]([c:5]1[H:29])[C@@:3]2([C:22](=[O:23])[N:20]([C:18](=[N+:17]2[H:37])[N:19]([H:38])[H:42])[C:21]([H:39])([H:40])[H:41])[C:2]([H:27])([H:28])[C:1]([H:24])([H:25])[H:26])[H:36])[c:9]3[c:10]([c:11]([c:12]([c:13]([c:15]3[H:35])[Cl:14])[H:34])[H:33])[H:32])[H:31]",
+            (
+                "[H:14][c:1]1[c:2]([c:5]([c:10]([c:6]([c:3]1[H:16])[H:19])[c:11]2[c:7]([c:4]([c:8]([c:12]([c:9]2[H:22])[Cl:13])[H:21])[H:17])[H:20])[H:18])[H:15]",
+                "[H:17][c:1]1[c:2]([c:4]([c:6]([c:5]([c:3]1[H:19])[H:21])[C@@:9]2([C:7](=[O:16])[N:13]([C:8](=[N+:14]2[H:30])[N:15]([H:31])[H:32])[C:11]([H:25])([H:26])[H:27])[C:12]([H:28])([H:29])[C:10]([H:22])([H:23])[H:24])[H:20])[H:18]",
+            ),
+        ),
+    ],
+)
+def test_wbo_regression(parent, fragments):
+    """Make sure we can produce the expected fragments using both openeye and AT+RDKIT."""
+    parent = Molecule.from_mapped_smiles(parent)
+    engine = WBOFragmenter(keep_non_rotor_ring_substituents=True, threshold=0.03)
+    result = engine.fragment(molecule=parent)
+    result_fragments = [fragment.molecule for fragment in result.fragments]
+    assert len(result_fragments) == 3
+    for fragment in fragments:
+        fragment_mol = Molecule.from_mapped_smiles(fragment)
+        assert fragment_mol in result_fragments
+
+
+def test_pfizer_regression():
+    """Make sure we can reproduce the example fragmentation from the implimentation paper."""
+    parent = Molecule.from_smiles(
+        "[H]c1c(c(c(c(c1C([H])([H])[H])[C@@]([H])(C([H])([H])[H])N([H])C(=O)N([H])C2=NC(=C(S2)[H])c3c(c(nc(c3[H])[H])[H])[H])C([H])([H])[H])OC([H])([H])[H])[H]",
+        hydrogens_are_explicit=True,
+    )
+    engine = PfizerFragmenter()
+    result = engine.fragment(molecule=parent)
+    # build the expected fragments
+    g_i_j = Molecule.from_smiles(
+        "[H]c1c(c(c(c(c1[H])C([H])([H])[H])[C@@]([H])(C([H])([H])[H])N([H])C(=O)N([H])C([H])([H])[H])C([H])([H])[H])[H]",
+        hydrogens_are_explicit=True,
+    )
+    h_l = Molecule.from_smiles(
+        "[H]C1=C(SC(=N1)N([H])C(=O)N([H])C([H])([H])[H])[H]",
+        hydrogens_are_explicit=True,
+    )
+    m = Molecule.from_smiles(
+        "[H]c1c(nc(c(c1C2=C(SC(=N2)[H])[H])[H])[H])[H]", hydrogens_are_explicit=True
+    )
+    k = Molecule.from_smiles(
+        "[H]c1c(c(c(c(c1[H])C([H])([H])[H])OC([H])([H])[H])[H])[H]",
+        hydrogens_are_explicit=True,
+    )
+    result_fragments = [fragment.molecule for fragment in result.fragments]
+    expected_fragments = [g_i_j, g_i_j, g_i_j, h_l, h_l, m, k]
+    assert Counter(result_fragments) == Counter(expected_fragments)

--- a/fragmenter/tests/test_regression.py
+++ b/fragmenter/tests/test_regression.py
@@ -1,17 +1,10 @@
 """
 Regression tests for the WBO and Pfizer fragmentation schemes.
 """
-from collections import Counter
-
 import pytest
 from openff.toolkit.topology import Molecule
 
-from fragmenter.fragment import (
-    FragmentationResult,
-    Fragmenter,
-    PfizerFragmenter,
-    WBOFragmenter,
-)
+from fragmenter.fragment import WBOFragmenter
 
 
 @pytest.mark.parametrize(
@@ -50,32 +43,3 @@ def test_wbo_regression(parent, fragments):
     for fragment in fragments:
         fragment_mol = Molecule.from_mapped_smiles(fragment)
         assert fragment_mol in result_fragments
-
-
-def test_pfizer_regression():
-    """Make sure we can reproduce the example fragmentation from the implimentation paper."""
-    parent = Molecule.from_smiles(
-        "[H]c1c(c(c(c(c1C([H])([H])[H])[C@@]([H])(C([H])([H])[H])N([H])C(=O)N([H])C2=NC(=C(S2)[H])c3c(c(nc(c3[H])[H])[H])[H])C([H])([H])[H])OC([H])([H])[H])[H]",
-        hydrogens_are_explicit=True,
-    )
-    engine = PfizerFragmenter()
-    result = engine.fragment(molecule=parent)
-    # build the expected fragments
-    g_i_j = Molecule.from_smiles(
-        "[H]c1c(c(c(c(c1[H])C([H])([H])[H])[C@@]([H])(C([H])([H])[H])N([H])C(=O)N([H])C([H])([H])[H])C([H])([H])[H])[H]",
-        hydrogens_are_explicit=True,
-    )
-    h_l = Molecule.from_smiles(
-        "[H]C1=C(SC(=N1)N([H])C(=O)N([H])C([H])([H])[H])[H]",
-        hydrogens_are_explicit=True,
-    )
-    m = Molecule.from_smiles(
-        "[H]c1c(nc(c(c1C2=C(SC(=N2)[H])[H])[H])[H])[H]", hydrogens_are_explicit=True
-    )
-    k = Molecule.from_smiles(
-        "[H]c1c(c(c(c(c1[H])C([H])([H])[H])OC([H])([H])[H])[H])[H]",
-        hydrogens_are_explicit=True,
-    )
-    result_fragments = [fragment.molecule for fragment in result.fragments]
-    expected_fragments = [g_i_j, g_i_j, g_i_j, h_l, h_l, m, k]
-    assert Counter(result_fragments) == Counter(expected_fragments)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ Fragment molecules for quantum mechanics torsion scans.
 """
 import sys
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 import versioneer
 
 short_description = __doc__.split("\n")

--- a/versioneer.py
+++ b/versioneer.py
@@ -277,10 +277,12 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 """
 
 from __future__ import print_function
+
 try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
+
 import errno
 import json
 import os
@@ -1561,6 +1563,7 @@ def get_cmdclass():
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
         from cx_Freeze.dist import build_exe as _build_exe
+
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{


### PR DESCRIPTION
## Description
This PR adds some regression tests for the WBO fragmentation scheme. The WBO examples are molecules that have provided the same fragments using the new code with both AT+RDKIT and OE which are also consistent with those given by fragmenter=0.0.7. 


## Status
- [x] Ready to go