### PR TITLE
Mark the regression tests as slow

### DIFF
--- a/openff/fragmenter/tests/conftest.py
+++ b/openff/fragmenter/tests/conftest.py
@@ -2,6 +2,25 @@ import pytest
 from openff.toolkit.topology import Molecule
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
 @pytest.fixture()
 def potanib() -> Molecule:
     return Molecule.from_smiles(

--- a/openff/fragmenter/tests/test_regression.py
+++ b/openff/fragmenter/tests/test_regression.py
@@ -32,6 +32,7 @@ from openff.toolkit.topology import Molecule
         ),
     ],
 )
+@pytest.mark.slow
 def test_wbo_regression(parent, fragments):
     """Make sure we can produce the expected fragments using both openeye and AT+RDKIT."""
     parent = Molecule.from_mapped_smiles(parent)


### PR DESCRIPTION
## Description

This PR flags the regression tests introduced in #112 as slow running as they can take >10 mins on the CI.

## Status
- [X] Ready to go